### PR TITLE
Introducing test specific jar to avoid weird constructions with test-jar

### DIFF
--- a/source/pom.xml
+++ b/source/pom.xml
@@ -255,6 +255,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
+        <module>taskmanager-test</module>
         <module>taskmanager-client</module>
         <module>taskmanager</module>
       </modules>

--- a/source/taskmanager-client/pom.xml
+++ b/source/taskmanager-client/pom.xml
@@ -98,6 +98,12 @@
     
     <!-- Testing -->
     <dependency>
+      <groupId>nl.aerius</groupId>
+      <artifactId>taskmanager-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -123,18 +129,6 @@
             </path>
           </annotationProcessorPaths>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/MockTaskResultHandler.java
+++ b/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/MockTaskResultHandler.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
+import nl.aerius.taskmanager.client.TaskResultCallback;
+
 /**
  *
  */

--- a/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/TaskManagerClientTest.java
+++ b/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/TaskManagerClientTest.java
@@ -38,6 +38,8 @@ import org.junit.Test;
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Connection;
 
+import nl.aerius.taskmanager.test.MockConnection;
+
 /**
  * Test class for {@link TaskManagerClientSender}.
  */

--- a/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/TaskResultConsumerTest.java
+++ b/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/TaskResultConsumerTest.java
@@ -34,6 +34,7 @@ import com.rabbitmq.client.ShutdownSignalException;
 
 import nl.aerius.taskmanager.client.TaskWrapper.TaskWrapperSender;
 import nl.aerius.taskmanager.client.util.QueueHelper;
+import nl.aerius.taskmanager.test.MockChannel;
 
 /**
  *

--- a/source/taskmanager-test/pom.xml
+++ b/source/taskmanager-test/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright the State of the Netherlands
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>nl.aerius</groupId>
+    <artifactId>taskmanager-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>taskmanager-test</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Taskmanager Test Library</name>
+  <description>A Library to help with testing Taskmanager (Client) code</description>
+
+  <dependencies>
+    <!-- RabbitMQ -->
+    <dependency>
+      <groupId>com.rabbitmq</groupId>
+      <artifactId>amqp-client</artifactId>
+    </dependency>
+    
+    <!-- Logging -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/source/taskmanager-test/src/main/java/nl/aerius/taskmanager/test/MockConnection.java
+++ b/source/taskmanager-test/src/main/java/nl/aerius/taskmanager/test/MockConnection.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager.client;
+package nl.aerius.taskmanager.test;
 
 import java.io.IOException;
 import java.net.InetAddress;

--- a/source/taskmanager/pom.xml
+++ b/source/taskmanager/pom.xml
@@ -69,6 +69,12 @@
 
     <!-- Testing -->
     <dependency>
+      <groupId>nl.aerius</groupId>
+      <artifactId>taskmanager-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
@@ -81,14 +87,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>nl.aerius</groupId>
-      <artifactId>taskmanager-client</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/AbstractRabbitMQTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/AbstractRabbitMQTest.java
@@ -30,9 +30,9 @@ import com.rabbitmq.client.Connection;
 
 import nl.aerius.taskmanager.adaptor.AdaptorFactory;
 import nl.aerius.taskmanager.client.BrokerConnectionFactory;
-import nl.aerius.taskmanager.client.MockChannel;
-import nl.aerius.taskmanager.client.MockConnection;
 import nl.aerius.taskmanager.client.configuration.ConnectionConfiguration;
+import nl.aerius.taskmanager.test.MockChannel;
+import nl.aerius.taskmanager.test.MockConnection;
 
 /**
  * Abstract base class for RabbitMQ tests.


### PR DESCRIPTION
While the test-jar approach works, it isn't really needed at this point I think.