### PR TITLE
Removed download-dependencies-step to fix docker build

### DIFF
--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -3,13 +3,7 @@ FROM maven:3-openjdk-8 as builder
 
 WORKDIR /app
 
-# First download as many dependencies as possible. This avoids downloading all dependencies each time something in source changes
-COPY pom.xml /app/
-COPY taskmanager/pom.xml /app/taskmanager/
-COPY taskmanager-client/pom.xml /app/taskmanager-client/
-RUN mvn package clean -Dmaven.main.skip -Dmaven.test.skip
-
-# Next do the actual build
+# Do the actual build
 COPY . /app
 RUN mvn clean package
 


### PR DESCRIPTION
Had to remove the download-dependencies-step because of the following:
While this works OK for 1-module builds, this does not really work in the case of dependencies between modules since no jar will be created.
Maven will not find the module that is depend upon in the local repository (no sources => no archive), and will try to download the dependency.
But since the build is not yet uploaded to nexus in case of releases, it won't be able to find it there, causing an error.