### PR TITLE
AER-2280 Add several timeouts in the RabbitMQQueueMonitor.

### DIFF
--- a/source/pom.xml
+++ b/source/pom.xml
@@ -107,7 +107,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.12</version>
+        <version>4.5.13</version>
       </dependency>
 
       <!-- Logging -->


### PR DESCRIPTION
AER-2280 Add several timeouts in the RabbitMQQueueMonitor. The timeout is set to 3 seconds. Updated apache httpclient to 4.5.13.