### PR TITLE
Added report project/profile to fix coverage reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn --no-transfer-progress -f source/pom.xml verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn --no-transfer-progress -f source/pom.xml verify sonar:sonar -P sonar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn --no-transfer-progress -f source/pom.xml verify sonar:sonar -P sonar
+        run: mvn --no-transfer-progress -f source/pom.xml -P sonar verify sonar:sonar

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Task Manager
 
+![Build Package](https://github.com/aerius/taskmanager/actions/workflows/publish_artifact.yml/badge.svg)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aerius_taskmanager&metric=alert_status)](https://sonarcloud.io/dashboard?id=aerius_taskmanager)
+
 The task manager is the central application through which all tasks are passed.
 The task manager controls the priority of the tasks.
 Tasks are grouped by the type of work that is performed.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Task Manager
 
-![Build Package](https://github.com/aerius/taskmanager/actions/workflows/publish_artifact.yml/badge.svg)
+[![Build Package](https://github.com/aerius/taskmanager/actions/workflows/publish_artifact.yml/badge.svg)](#)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aerius_taskmanager&metric=alert_status)](https://sonarcloud.io/dashboard?id=aerius_taskmanager)
 
 The task manager is the central application through which all tasks are passed.

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -151,19 +151,26 @@
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>4.0.3</version>
-        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>5.7.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.5.9</version>
-        <scope>test</scope>
+        <version>3.6.0</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13</version>
-        <scope>test</scope>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>3.6.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -176,6 +183,12 @@
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>0.8.6</version>
         </plugin>
+
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.2</version>
+        </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -23,7 +23,7 @@
   <artifactId>taskmanager-parent</artifactId>
   <version>1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>Taskmanager :: Parent</name>
+  <name>Taskmanager</name>
   <url>https://www.aerius.nl</url>
 
   <organization>
@@ -59,6 +59,7 @@
     <maven.compiler.target>11</maven.compiler.target>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <aerius-tools.version>1.1.0-SNAPSHOT</aerius-tools.version>
     <spotless.version>2.5.0</spotless.version>
     <dropwizard.metrics.version>3.1.2</dropwizard.metrics.version>
@@ -68,7 +69,7 @@
     <sonar.organization>aerius</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-    <aggregate.report.dir>target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
+    <aggregate.report.dir>taskmanager-report/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
   </properties>
 
   <repositories>
@@ -314,6 +315,18 @@
         <module>taskmanager-test</module>
         <module>taskmanager-client</module>
         <module>taskmanager</module>
+      </modules>
+    </profile>
+
+    <!-- Profile to perform SonarQube run and collect coverage reports -->
+    <profile>
+      <id>sonar</id>
+
+      <modules>
+        <module>taskmanager-test</module>
+        <module>taskmanager-client</module>
+        <module>taskmanager</module>
+        <module>taskmanager-report</module>
       </modules>
     </profile>
 

--- a/source/taskmanager-client/pom.xml
+++ b/source/taskmanager-client/pom.xml
@@ -87,8 +87,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/BrokerConnectionFactoryTest.java
+++ b/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/BrokerConnectionFactoryTest.java
@@ -16,13 +16,15 @@
  */
 package nl.aerius.taskmanager.client;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import nl.aerius.taskmanager.client.configuration.ConnectionConfiguration;
 
@@ -33,70 +35,86 @@ public class BrokerConnectionFactoryTest {
 
   private static ExecutorService executor;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() {
     executor = Executors.newSingleThreadExecutor();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     executor.shutdown();
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testTaskManagerClientWithoutBrokerHost() throws IOException {
-    final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
-    builder.brokerHost(null);
-    new BrokerConnectionFactory(executor, builder.build());
+    assertThrows(NullPointerException.class, () -> {
+      final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
+      builder.brokerHost(null);
+      new BrokerConnectionFactory(executor, builder.build());
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testTaskManagerClientWithEmptyBrokerHost() throws IOException {
-    final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
-    builder.brokerHost("");
-    new BrokerConnectionFactory(executor, builder.build());
+    assertThrows(IllegalArgumentException.class, () -> {
+      final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
+      builder.brokerHost("");
+      new BrokerConnectionFactory(executor, builder.build());
+    });
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testTaskManagerClientWithoutBrokerUsername() throws IOException {
-    final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
-    builder.brokerUsername(null);
-    new BrokerConnectionFactory(executor, builder.build());
+    assertThrows(NullPointerException.class, () -> {
+      final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
+      builder.brokerUsername(null);
+      new BrokerConnectionFactory(executor, builder.build());
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testTaskManagerClientWithEmptyBrokerUsername() throws IOException {
-    final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
-    builder.brokerUsername("");
-    new BrokerConnectionFactory(executor, builder.build());
+    assertThrows(IllegalArgumentException.class, () -> {
+      final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
+      builder.brokerUsername("");
+      new BrokerConnectionFactory(executor, builder.build());
+    });
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testTaskManagerClientWithoutBrokerPassword() throws IOException {
-    final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
-    builder.brokerPassword(null);
-    new BrokerConnectionFactory(executor, builder.build());
+    assertThrows(NullPointerException.class, () -> {
+      final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
+      builder.brokerPassword(null);
+      new BrokerConnectionFactory(executor, builder.build());
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testTaskManagerClientWithEmptyBrokerPassword() throws IOException {
-    final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
-    builder.brokerPassword("");
-    new BrokerConnectionFactory(executor, builder.build());
+    assertThrows(IllegalArgumentException.class, () -> {
+      final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
+      builder.brokerPassword("");
+      new BrokerConnectionFactory(executor, builder.build());
+    });
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testTaskManagerClientWithoutBrokerVirtualHost() throws IOException {
-    final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
-    builder.brokerVirtualHost(null);
-    new BrokerConnectionFactory(executor, builder.build());
+    assertThrows(NullPointerException.class, () -> {
+      final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
+      builder.brokerVirtualHost(null);
+      new BrokerConnectionFactory(executor, builder.build());
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testTaskManagerClientWithEmptyBrokerVirtualHost() throws IOException {
-    final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
-    builder.brokerVirtualHost("");
-    new BrokerConnectionFactory(executor, builder.build());
+    assertThrows(IllegalArgumentException.class, () -> {
+      final ConnectionConfiguration.Builder builder = getFullConnectionConfigurationBuilder();
+      builder.brokerVirtualHost("");
+      new BrokerConnectionFactory(executor, builder.build());
+    });
   }
 
   private ConnectionConfiguration.Builder getFullConnectionConfigurationBuilder() {

--- a/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/TaskResultConsumerTest.java
+++ b/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/TaskResultConsumerTest.java
@@ -16,18 +16,19 @@
  */
 package nl.aerius.taskmanager.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.ShutdownSignalException;
@@ -37,7 +38,7 @@ import nl.aerius.taskmanager.client.util.QueueHelper;
 import nl.aerius.taskmanager.test.MockChannel;
 
 /**
- *
+ * Test class for {@link TaskResultConsumer}.
  */
 public class TaskResultConsumerTest {
 
@@ -48,7 +49,7 @@ public class TaskResultConsumerTest {
   private MockTaskSender sender;
   private MockChannel channel;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     sender = new MockTaskSender();
     channel = new MockChannel();
@@ -63,16 +64,16 @@ public class TaskResultConsumerTest {
     final BasicProperties props = new BasicProperties.Builder().correlationId(propsCorrelationId).build();
     final String resultObject = "Success!";
 
-    assertTrue("Before handling the channel should still be open", channel.isOpen());
+    assertTrue(channel.isOpen(), "Before handling the channel should still be open");
     consumer.handleDelivery(CONSUMER_TAG, null, props, QueueHelper.objectToBytes(resultObject));
     //because it's a mockchannel, we can actually use the consumer to handle another delivery...
     //that's what the test on channel.isOpen is for.
-    assertFalse("After handling the channel should be closed", channel.isOpen());
+    assertFalse(channel.isOpen(), "After handling the channel should be closed");
 
-    assertNull("Shouldn't resend", sender.wrapperSendAgain);
-    assertNull("Received exception should be null", resultCallback.receivedException);
-    assertEquals("Received result object", resultObject, resultCallback.successObject);
-    assertEquals("Received task ID", propsCorrelationId, resultCallback.correlationId);
+    assertNull(sender.wrapperSendAgain, "Shouldn't resend");
+    assertNull(resultCallback.receivedException, "Received exception should be null");
+    assertEquals(resultObject, resultCallback.successObject, "Received result object");
+    assertEquals(propsCorrelationId, resultCallback.correlationId, "Received task ID");
   }
 
   @Test
@@ -84,17 +85,17 @@ public class TaskResultConsumerTest {
     final BasicProperties props = new BasicProperties.Builder().correlationId(propsCorrelationId).build();
     final Exception resultObject = new RuntimeException();
 
-    assertTrue("Before handling the channel should still be open", channel.isOpen());
+    assertTrue(channel.isOpen(), "Before handling the channel should still be open");
     consumer.handleDelivery(CONSUMER_TAG, null, props, QueueHelper.objectToBytes(resultObject));
     //because it's a mockchannel, we can actually use the consumer to handle another delivery...
     //that's what the test on channel.isOpen is for.
-    assertFalse("After handling the channel should be closed", channel.isOpen());
+    assertFalse(channel.isOpen(), "After handling the channel should be closed");
 
-    assertNull("Shouldn't resend", sender.wrapperSendAgain);
-    assertNull("Received result object should be null", resultCallback.successObject);
+    assertNull(sender.wrapperSendAgain, "Shouldn't resend");
+    assertNull(resultCallback.successObject, "Received result object should be null");
     //after serializing/deserializing by default objects aren't exactly equal (unless they override equals in some way).
-    assertTrue("Received exception", resultCallback.receivedException instanceof RuntimeException);
-    assertEquals("Received task ID", propsCorrelationId, resultCallback.correlationId);
+    assertTrue(resultCallback.receivedException instanceof RuntimeException, "Received exception");
+    assertEquals(propsCorrelationId, resultCallback.correlationId, "Received task ID");
   }
 
   @Test
@@ -106,26 +107,26 @@ public class TaskResultConsumerTest {
     final BasicProperties props = new BasicProperties.Builder().correlationId(propsCorrelationId).build();
     final String resultObject = "Success!";
 
-    assertTrue("Before handling the channel should still be open", channel.isOpen());
+    assertTrue(channel.isOpen(), "Before handling the channel should still be open");
     consumer.handleDelivery(CONSUMER_TAG, null, props, QueueHelper.objectToBytes(resultObject));
-    assertTrue("After handling the channel should still be open", channel.isOpen());
+    assertTrue(channel.isOpen(), "After handling the channel should still be open");
 
-    assertNull("Shouldn't resend", sender.wrapperSendAgain);
-    assertNull("Received exception should be null", resultCallback.receivedException);
-    assertEquals("Received result object", resultObject, resultCallback.successObject);
-    assertEquals("Received task ID", propsCorrelationId, resultCallback.correlationId);
-    assertEquals("Cancel listener", consumer, resultCallback.cancelListener);
+    assertNull(sender.wrapperSendAgain, "Shouldn't resend");
+    assertNull(resultCallback.receivedException, "Received exception should be null");
+    assertEquals(resultObject, resultCallback.successObject, "Received result object");
+    assertEquals(propsCorrelationId, resultCallback.correlationId, "Received task ID");
+    assertEquals(consumer, resultCallback.cancelListener, "Cancel listener");
 
     consumer.handleDelivery(CONSUMER_TAG, null, props, QueueHelper.objectToBytes(resultObject));
-    assertTrue("After handling the channel still be open", channel.isOpen());
+    assertTrue(channel.isOpen(), "After handling the channel still be open");
 
     consumer.handleDelivery(CONSUMER_TAG, null, props, QueueHelper.objectToBytes(FINAL_RESULT));
-    assertFalse("After handling the final object, the channel should be closed", channel.isOpen());
+    assertFalse(channel.isOpen(), "After handling the final object, the channel should be closed");
 
-    assertNull("Shouldn't resend", sender.wrapperSendAgain);
-    assertNull("Received exception should be null", resultCallback.receivedException);
-    assertEquals("Received result object", FINAL_RESULT, resultCallback.successObject);
-    assertEquals("Received task ID", propsCorrelationId, resultCallback.correlationId);
+    assertNull(sender.wrapperSendAgain, "Shouldn't resend");
+    assertNull(resultCallback.receivedException, "Received exception should be null");
+    assertEquals(FINAL_RESULT, resultCallback.successObject, "Received result object");
+    assertEquals(propsCorrelationId, resultCallback.correlationId, "Received task ID");
   }
 
   @Test
@@ -137,18 +138,18 @@ public class TaskResultConsumerTest {
     final BasicProperties props = new BasicProperties.Builder().correlationId(propsCorrelationId).build();
     final String resultObject = "Success!";
 
-    assertTrue("Before handling the channel should still be open", channel.isOpen());
+    assertTrue(channel.isOpen(), "Before handling the channel should still be open");
     consumer.handleDelivery(CONSUMER_TAG, null, props, QueueHelper.objectToBytes(resultObject));
-    assertTrue("After handling the channel should still be open", channel.isOpen());
+    assertTrue(channel.isOpen(), "After handling the channel should still be open");
 
-    assertNull("Shouldn't resend", sender.wrapperSendAgain);
-    assertNull("Received exception should be null", resultCallback.receivedException);
-    assertEquals("Received result object", resultObject, resultCallback.successObject);
-    assertEquals("Received task ID", propsCorrelationId, resultCallback.correlationId);
+    assertNull(sender.wrapperSendAgain, "Shouldn't resend");
+    assertNull(resultCallback.receivedException, "Received exception should be null");
+    assertEquals(resultObject, resultCallback.successObject, "Received result object");
+    assertEquals(propsCorrelationId, resultCallback.correlationId, "Received task ID");
 
     consumer.handleDelivery(CONSUMER_TAG, null, props, QueueHelper.objectToBytes(new RuntimeException()));
-    assertFalse("After handling an exception the channel should close", channel.isOpen());
-    assertTrue("Received exception", resultCallback.receivedException instanceof RuntimeException);
+    assertFalse(channel.isOpen(), "After handling an exception the channel should close");
+    assertTrue(resultCallback.receivedException instanceof RuntimeException, "Received exception");
 
     //at this point we can retry handling another delivery, but since we're mocking the channel and such...
     //when the channel is closed, you can assume no more messages will be delivered.
@@ -157,13 +158,13 @@ public class TaskResultConsumerTest {
   @Test
   public void testCancelMultipleResultsTask() throws IOException {
     final MultipleResultCallback resultCallback = new MultipleResultCallback();
-    assertNull("Cancel listener", resultCallback.cancelListener);
+    assertNull(resultCallback.cancelListener, "Cancel listener");
     final TaskResultConsumer consumer = new TaskResultConsumer(channel, getExampleTaskWrapper(resultCallback), sender);
-    assertEquals("Cancel listener after using it for a consumer", consumer, resultCallback.cancelListener);
+    assertEquals(consumer, resultCallback.cancelListener, "Cancel listener after using it for a consumer");
 
-    assertTrue("Before canceling, the channel should be open", channel.isOpen());
+    assertTrue(channel.isOpen(), "Before canceling, the channel should be open");
     resultCallback.cancelListener.cancelCurrentTask();
-    assertFalse("After canceling, the channel should be closed", channel.isOpen());
+    assertFalse(channel.isOpen(), "After canceling, the channel should be closed");
   }
 
   private TaskWrapper getExampleTaskWrapper(final TaskResultCallback resultCallback) {
@@ -178,10 +179,10 @@ public class TaskResultConsumerTest {
     final TaskWrapper taskWrapper = getExampleTaskWrapper(resultCallback);
     final TaskResultConsumer consumer = new TaskResultConsumer(channel, taskWrapper, sender);
     consumer.handleShutdownSignal(CONSUMER_TAG, new ShutdownSignalException(true, false, "", ""));
-    assertEquals("A retry on sending the task again should occur", taskWrapper, sender.wrapperSendAgain);
-    assertNull("Received exception should be null", resultCallback.receivedException);
-    assertNull("Received result should be null", resultCallback.successObject);
-    assertNull("Received task ID should be null", resultCallback.correlationId);
+    assertEquals(taskWrapper, sender.wrapperSendAgain, "A retry on sending the task again should occur");
+    assertNull(resultCallback.receivedException, "Received exception should be null");
+    assertNull(resultCallback.successObject, "Received result should be null");
+    assertNull(resultCallback.correlationId, "Received task ID should be null");
   }
 
   @Test
@@ -190,16 +191,18 @@ public class TaskResultConsumerTest {
     final TaskWrapper taskWrapper = getExampleTaskWrapper(resultCallback);
     final TaskResultConsumer consumer = new TaskResultConsumer(channel, taskWrapper, sender);
     consumer.handleShutdownSignal(CONSUMER_TAG, new ShutdownSignalException(true, true, "", ""));
-    assertNull("No retry, we shut ourselves down", sender.wrapperSendAgain);
-    assertNull("Received exception should be null", resultCallback.receivedException);
-    assertNull("Received result should be null", resultCallback.successObject);
-    assertNull("Received task ID should be null", resultCallback.correlationId);
+    assertNull(sender.wrapperSendAgain, "No retry, we shut ourselves down");
+    assertNull(resultCallback.receivedException, "Received exception should be null");
+    assertNull(resultCallback.successObject, "Received result should be null");
+    assertNull(resultCallback.correlationId, "Received task ID should be null");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testWrapperWithoutCallback() {
-    final TaskWrapper taskWrapper = new TaskWrapper(Optional.empty(), new TestTaskInput(), "Other", "One", "Shouldn't Matter", WORKER_TYPE_TEST);
-    new TaskResultConsumer(channel, taskWrapper, sender);
+    assertThrows(IllegalArgumentException.class, () -> {
+      final TaskWrapper taskWrapper = new TaskWrapper(Optional.empty(), new TestTaskInput(), "Other", "One", "Shouldn't Matter", WORKER_TYPE_TEST);
+      new TaskResultConsumer(channel, taskWrapper, sender);
+    });
   }
 
   private static class SingleResultCallback implements TaskResultCallback {

--- a/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/mq/RabbitMQQueueMonitorTest.java
+++ b/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/mq/RabbitMQQueueMonitorTest.java
@@ -16,7 +16,7 @@
  */
 package nl.aerius.taskmanager.client.mq;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,7 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
@@ -74,8 +74,8 @@ public class RabbitMQQueueMonitorTest {
       executor.execute(rpm);
       Thread.sleep(TimeUnit.SECONDS.toMillis(1));
       rpm.shutdown();
-      assertEquals("Number of workers", 4, workerSize.get());
-      assertEquals("Number of messages", 3, messagesSize.get());
+      assertEquals(4, workerSize.get(), "Number of workers");
+      assertEquals(3, messagesSize.get(), "Number of messages");
     } finally {
       executor.shutdown();
     }

--- a/source/taskmanager-report/pom.xml
+++ b/source/taskmanager-report/pom.xml
@@ -1,0 +1,73 @@
+<!--
+
+    Copyright the State of the Netherlands
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>nl.aerius</groupId>
+    <artifactId>taskmanager-parent</artifactId>
+    <version>1.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>taskmanager-report</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Taskmanager :: Report</name>
+  <description>AERIUS Taskmanager SonarQube Jacoco module to collect Covarage reports</description>
+
+  <properties>
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>nl.aerius</groupId>
+      <artifactId>taskmanager-test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>nl.aerius</groupId>
+      <artifactId>taskmanager-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>nl.aerius</groupId>
+      <artifactId>taskmanager</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>report</id>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>          
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/source/taskmanager/pom.xml
+++ b/source/taskmanager/pom.xml
@@ -71,8 +71,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -101,6 +101,19 @@
             </manifestEntries>
           </archive>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/ConfigurationManagerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/ConfigurationManagerTest.java
@@ -16,13 +16,14 @@
  */
 package nl.aerius.taskmanager;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.util.Properties;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import nl.aerius.taskmanager.domain.TaskManagerConfiguration;
 
@@ -33,16 +34,17 @@ public class ConfigurationManagerTest {
 
   private Properties properties;
 
-  @Before
+  @BeforeEach
   public void before() throws IOException {
     final String propFile = getClass().getClassLoader().getResource("taskmanager_test.properties").getPath();
     properties = ConfigurationManager.getPropertiesFromFile(propFile);
   }
 
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(2000)
   public void testLoadConfiguration() throws IOException {
     final TaskManagerConfiguration tmc = ConfigurationManager.loadConfiguration(properties);
 
-    assertNotNull("No username could be read from configuration file", tmc.getBrokerConfiguration().getBrokerUsername());
+    assertNotNull(tmc.getBrokerConfiguration().getBrokerUsername(), "No username could be read from configuration file");
   }
 }

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/PriorityTaskSchedulerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/PriorityTaskSchedulerTest.java
@@ -17,11 +17,11 @@
 package nl.aerius.taskmanager;
 
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,8 +34,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import nl.aerius.taskmanager.PriorityTaskScheduler.PriorityTaskSchedulerFactory;
 import nl.aerius.taskmanager.domain.Message;
@@ -62,7 +63,7 @@ public class PriorityTaskSchedulerTest {
   private Task task3;
   private PriorityTaskScheduler scheduler;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, InterruptedException {
     taskConsumer1 = createMockTaskConsumer(QUEUE1);
     taskConsumer2 = createMockTaskConsumer(QUEUE2);
@@ -82,61 +83,66 @@ public class PriorityTaskSchedulerTest {
     task3 = createTask(taskConsumer3, "3", QUEUE3);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5000)
   public void testCompare() throws InterruptedException {
-    assertTrue("Compare Ok", compare(task1, task2a, 1));
+    assertTrue(compare(task1, task2a, 1), "Compare Ok");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5000)
   public void testCompareReverse() throws InterruptedException {
-    assertTrue("Compare reserve Ok", compare(task2a, task1, -1));
+    assertTrue(compare(task2a, task1, -1), "Compare reserve Ok");
   }
 
   private boolean compare(final Task taskA, final Task taskB, final int returnResult) throws InterruptedException {
     scheduler.onWorkerPoolSizeChange(3);
-    assertEquals("Task with higher priority and no tasks running should be returned", returnResult,
-        scheduler.compare(taskA, taskB));
+    assertEquals(returnResult, scheduler.compare(taskA, taskB),
+        "Task with higher priority and no tasks running should be returned");
     scheduler.addTask(task2a);
-    assertSame("Should get task2a back.", task2a, scheduler.getNextTask());
-    assertEquals("Task with lower priority, but no task run yet should be done returned", -returnResult,
-        scheduler.compare(taskA, taskB));
+    assertSame(task2a, scheduler.getNextTask(), "Should get task2a back.");
+    assertEquals(-returnResult, scheduler.compare(taskA, taskB),
+        "Task with lower priority, but no task run yet should be done returned");
     scheduler.addTask(task1);
-    assertSame("Should get task1 back.", task1, scheduler.getNextTask());
-    assertEquals("Task with higher priority should be returned when both with tasks running ", returnResult,
-        scheduler.compare(taskA, taskB));
+    assertSame(task1, scheduler.getNextTask(), "Should get task1 back.");
+    assertEquals(returnResult, scheduler.compare(taskA, taskB),
+        "Task with higher priority should be returned when both with tasks running ");
     return true;
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5000)
   public void testCompareSame() throws InterruptedException {
-    assertTrue("Compare same Ok", compareSame(task2a, task3, -1));
+    assertTrue(compareSame(task2a, task3, -1), "Compare same Ok");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5000)
   public void testCompareSameReverse() throws InterruptedException {
-    assertTrue("Compare same reserve Ok", compareSame(task3, task2a, 1));
+    assertTrue(compareSame(task3, task2a, 1), "Compare same reserve Ok");
   }
 
   private boolean compareSame(final Task taskA, final Task taskB, final int returnResult) throws InterruptedException {
     scheduler.onWorkerPoolSizeChange(4);
-    assertEquals("Task with same priority and no tasks running return 0", 0,
-        scheduler.compare(taskA, taskB));
+    assertEquals(0, scheduler.compare(taskA, taskB),
+        "Task with same priority and no tasks running return 0");
     scheduler.addTask(task2a);
-    assertSame("Should get task2a back.", task2a, scheduler.getNextTask());
-    assertEquals("Task with same priority, but no task run yet should be done returned", returnResult,
-        scheduler.compare(taskA, taskB));
+    assertSame(task2a, scheduler.getNextTask(), "Should get task2a back.");
+    assertEquals(returnResult, scheduler.compare(taskA, taskB),
+        "Task with same priority, but no task run yet should be done returned");
     scheduler.addTask(task3);
-    assertSame("Should get task3 back.", task3, scheduler.getNextTask());
-    assertEquals("Task with same priority should return 0", 0,
-        scheduler.compare(taskA, taskB));
+    assertSame(task3, scheduler.getNextTask(), "Should get task3 back.");
+    assertEquals(0, scheduler.compare(taskA, taskB),
+        "Task with same priority should return 0");
     scheduler.addTask(task2b);
-    assertSame("Should get task2b back.", task2b, scheduler.getNextTask());
-    assertEquals("Task with same priority, but one with more running, should run with less running", -returnResult,
-        scheduler.compare(taskA, taskB));
+    assertSame(task2b, scheduler.getNextTask(), "Should get task2b back.");
+    assertEquals(-returnResult, scheduler.compare(taskA, taskB),
+        "Task with same priority, but one with more running, should run with less running");
     return true;
   }
 
-  @Test(timeout = 7000)
+  @Test
+  @Timeout(7000)
   public void testGetTaskWith1WorkerAvailable() throws InterruptedException, ExecutionException {
     scheduler.onWorkerPoolSizeChange(1);
     final Task task1 = createTask(taskConsumer1, "1", QUEUE1); //add task with priority 0.
@@ -144,8 +150,8 @@ public class PriorityTaskSchedulerTest {
     final AtomicInteger chkCounter = new AtomicInteger();
     final Future<Task> receivedTask = waitForTask(task1, chkCounter);
     await().atMost(1, TimeUnit.SECONDS).until(receivedTask::isDone);
-    assertNotNull("Received task", receivedTask.get());
-    assertEquals("Counter should be 1 when only one slot available", 1, chkCounter.intValue());
+    assertNotNull(receivedTask.get(), "Received task");
+    assertEquals(1, chkCounter.intValue(), "Counter should be 1 when only one slot available");
   }
 
   /**
@@ -153,7 +159,8 @@ public class PriorityTaskSchedulerTest {
    * If only 1 slot available and the next task is a low priority of the queue on which already another process is running,
    * it should not be run until that more than one or the task of that queue is finished.
    */
-  @Test(timeout = 7000)
+  @Test
+  @Timeout(7000)
   public void testGetTask() throws InterruptedException, ExecutionException {
     scheduler.onWorkerPoolSizeChange(2);
     final Task task1a = createTask(taskConsumer1, "1a", QUEUE1);
@@ -161,23 +168,23 @@ public class PriorityTaskSchedulerTest {
     final Task task1b = createTask(taskConsumer1, "1b", QUEUE1);
     scheduler.addTask(task1b);
     scheduler.addTask(task2a);
-    assertSame("Should get task2a back.", task2a, scheduler.getNextTask());
-    assertSame("Should get task1a back.", task1a, scheduler.getNextTask());
+    assertSame(task2a, scheduler.getNextTask(), "Should get task2a back.");
+    assertSame(task1a, scheduler.getNextTask(), "Should get task1a back.");
     final AtomicInteger chkCounter = new AtomicInteger();
     final Future<Task> receivedTask = waitForTask(task1b, chkCounter);
     await().pollDelay(1, TimeUnit.SECONDS).until(() -> true);
-    assertEquals("Counter should still be zero", 0, chkCounter.intValue());
-    assertFalse("Should not be done yet", receivedTask.isDone());
+    assertEquals(0, chkCounter.intValue(), "Counter should still be zero");
+    assertFalse(receivedTask.isDone(), "Should not be done yet");
     scheduler.onTaskFinished(task2a.getMessage().getMetaData().getQueueName());
     await().pollDelay(1, TimeUnit.SECONDS).until(() -> true);
     // task2a finished, but task1b may still not be executed, because only 1 slot available.
-    assertEquals("Counter should still be zero when 1 slot priorty available", 0, chkCounter.intValue());
-    assertFalse("Should not be done yet", receivedTask.isDone());
+    assertEquals(0, chkCounter.intValue(), "Counter should still be zero when 1 slot priorty available");
+    assertFalse(receivedTask.isDone(), "Should not be done yet");
     scheduler.onTaskFinished(task1a.getMessage().getMetaData().getQueueName());
     await().atMost(1, TimeUnit.SECONDS).until(() -> receivedTask.isDone());
-    assertNotNull("Received task", receivedTask.get());
+    assertNotNull(receivedTask.get(), "Received task");
     // task1a finished, now task1b may be executed.
-    assertEquals("Counter should still be 1", 1, chkCounter.intValue());
+    assertEquals(1, chkCounter.intValue(), "Counter should still be 1");
   }
 
   /**
@@ -185,7 +192,8 @@ public class PriorityTaskSchedulerTest {
    * If capacity is reached for a task, it should not run unless a task of the same queue is returned as finished.
    * In the meanwhile, other tasks can start/finish (as long as there is a capacity for those tasks).
    */
-  @Test(timeout = 7000)
+  @Test
+  @Timeout(7000)
   public void testGetTaskBigPool() throws InterruptedException, ExecutionException {
     scheduler.onWorkerPoolSizeChange(10);
     final List<Task> tasks = new ArrayList<>();
@@ -200,26 +208,26 @@ public class PriorityTaskSchedulerTest {
       sendTasks.add(sendTask);
     }
     scheduler.addTask(task1);
-    assertSame("Should still get task 1", task1, scheduler.getNextTask());
+    assertSame(task1, scheduler.getNextTask(), "Should still get task 1");
     final Task task1b = createTask(taskConsumer1, "1b", QUEUE1);
     scheduler.addTask(task1b);
-    assertSame("Should still get task 1b", task1b, scheduler.getNextTask());
+    assertSame(task1b, scheduler.getNextTask(), "Should still get task 1b");
     final AtomicInteger chkCounter = new AtomicInteger();
     final Future<Task> receivedTask = waitForTask(null, chkCounter);
     await().pollDelay(1, TimeUnit.SECONDS).until(() -> true);
-    assertEquals("Counter should still be zero", 0, chkCounter.intValue());
-    assertFalse("Should not be done yet", receivedTask.isDone());
+    assertEquals(0, chkCounter.intValue(), "Counter should still be zero");
+    assertFalse(receivedTask.isDone(), "Should not be done yet");
     scheduler.onTaskFinished(task1.getMessage().getMetaData().getQueueName());
     scheduler.onTaskFinished(task1b.getMessage().getMetaData().getQueueName());
     await().pollDelay(1, TimeUnit.SECONDS).until(() -> true);
     // task1's are finished, but tasks on 2 may still not be executed, because not enough slots available.
-    assertEquals("Counter should still be zero when capacity not reached", 0, chkCounter.intValue());
-    assertFalse("Should not be done yet", receivedTask.isDone());
+    assertEquals(0, chkCounter.intValue(), "Counter should still be zero when capacity not reached");
+    assertFalse(receivedTask.isDone(), "Should not be done yet");
     scheduler.onTaskFinished(sendTasks.get(0).getMessage().getMetaData().getQueueName());
     await().atMost(1, TimeUnit.SECONDS).until(receivedTask::isDone);
-    assertNotNull("Received task", receivedTask.get());
+    assertNotNull(receivedTask.get(), "Received task");
     // One of the task2's is now finished, another task2 may be executed.
-    assertEquals("Counter should increase because there is enough capacity now", 1, chkCounter.intValue());
+    assertEquals(1, chkCounter.intValue(), "Counter should increase because there is enough capacity now");
   }
 
   /**
@@ -227,15 +235,16 @@ public class PriorityTaskSchedulerTest {
    * the task of queue 3 should be selected.
    * @throws InterruptedException
    */
-  @Test(timeout = 1000)
+  @Test
+  @Timeout(1000)
   public void testCompare2Workers() throws InterruptedException {
     scheduler.onWorkerPoolSizeChange(2);
     scheduler.addTask(task2a);
     scheduler.getNextTask();
-    assertEquals("Scheduler should prefer task3", 1, scheduler.compare(task2b, task3));
+    assertEquals(1, scheduler.compare(task2b, task3), "Scheduler should prefer task3");
     scheduler.addTask(task2b);
     scheduler.addTask(task3);
-    assertSame("Scheduler should prefer task3", task3, scheduler.getNextTask());
+    assertSame(task3, scheduler.getNextTask(), "Scheduler should prefer task3");
   }
 
   private Future<Task> waitForTask(final Task task, final AtomicInteger chkCounter) {
@@ -247,9 +256,9 @@ public class PriorityTaskSchedulerTest {
         try {
           result = scheduler.getNextTask();
           if (task == null) {
-            assertNotNull("Should get any task back", result);
+            assertNotNull(result, "Should get any task back");
           } else {
-            assertSame("Should get task back.", task, result);
+            assertSame(task, result, "Should get task back.");
           }
           chkCounter.incrementAndGet();
         } catch (final InterruptedException e) {

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/QueueWatchDogTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/QueueWatchDogTest.java
@@ -17,13 +17,13 @@
 package nl.aerius.taskmanager;
 
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@link QueueWatchDog}.
@@ -38,18 +38,18 @@ public class QueueWatchDogTest {
         return diff / 100; //1th of a second
       };
     };
-    assertFalse("No running workers, with no messages, no problem", qwd.isItDead(false, 0));
-    assertFalse("No running workers, no problem", qwd.isItDead(false, 10));
-    assertFalse("Running workers, with messages, no problem", qwd.isItDead(true, 10));
-    assertFalse("Running workers, with no messages, possible problem, we just wait", qwd.isItDead(true, 0));
+    assertFalse(qwd.isItDead(false, 0), "No running workers, with no messages, no problem");
+    assertFalse(qwd.isItDead(false, 10), "No running workers, no problem");
+    assertFalse(qwd.isItDead(true, 10), "Running workers, with messages, no problem");
+    assertFalse(qwd.isItDead(true, 0), "Running workers, with no messages, possible problem, we just wait");
     await().atMost(2, TimeUnit.SECONDS).until(() -> qwd.isItDead(true, 0));
-    assertTrue("Running workers, with no messages, after specified time; yes reset", qwd.isItDead(true, 0));
+    assertTrue(qwd.isItDead(true, 0), "Running workers, with no messages, after specified time; yes reset");
   }
 
   @Test
   public void testCalculatedDiffTime() {
     final QueueWatchDog qwd = new QueueWatchDog();
     final long minutes = 10;
-    assertEquals("Check if correctly calcualted in minutes", minutes, qwd.calculatedDiffTime(TimeUnit.MINUTES.toMillis(minutes)));
+    assertEquals(minutes, qwd.calculatedDiffTime(TimeUnit.MINUTES.toMillis(minutes)), "Check if correctly calcualted in minutes");
   }
 }

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskManagerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskManagerTest.java
@@ -16,8 +16,8 @@
  */
 package nl.aerius.taskmanager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,9 +26,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.codahale.metrics.MetricRegistry;
 
@@ -48,7 +48,7 @@ public class TaskManagerTest {
   private PriorityTaskSchedule schedule;
   private TaskManager<PriorityTaskQueue, PriorityTaskSchedule> taskManager;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, InterruptedException {
     executor = Executors.newCachedThreadPool();
     MetricFactory.init(new Properties(), "test");
@@ -58,7 +58,7 @@ public class TaskManagerTest {
     schedule = handler.read(new File(getClass().getClassLoader().getResource("queue/priority-task-scheduler.ops.json").getFile()));
   }
 
-  @After
+  @AfterEach
   public void after() throws InterruptedException {
     taskManager.shutdown();
     executor.shutdownNow();
@@ -68,30 +68,30 @@ public class TaskManagerTest {
 
   @Test
   public void testAddScheduler() throws IOException, InterruptedException {
-    assertTrue("TaskScheduler running", taskManager.updateTaskScheduler(schedule));
+    assertTrue(taskManager.updateTaskScheduler(schedule), "TaskScheduler running");
     taskManager.removeTaskScheduler(schedule.getWorkerQueueName());
   }
 
   @Test
   public void testModifyQueue() throws IOException, InterruptedException {
-    assertTrue("TaskScheduler running", taskManager.updateTaskScheduler(schedule));
+    assertTrue(taskManager.updateTaskScheduler(schedule), "TaskScheduler running");
     schedule.getTaskQueues().get(0).setPriority(30);
-    assertTrue("TaskScheduler updated", taskManager.updateTaskScheduler(schedule));
+    assertTrue(taskManager.updateTaskScheduler(schedule), "TaskScheduler updated");
     taskManager.removeTaskScheduler(schedule.getWorkerQueueName());
   }
 
   @Test
   public void testRemoveQueue() throws IOException, InterruptedException {
-    assertTrue("TaskScheduler running", taskManager.updateTaskScheduler(schedule));
+    assertTrue(taskManager.updateTaskScheduler(schedule), "TaskScheduler running");
     schedule.getTaskQueues().remove(0);
-    assertTrue("TaskScheduler updated", taskManager.updateTaskScheduler(schedule));
+    assertTrue(taskManager.updateTaskScheduler(schedule), "TaskScheduler updated");
     taskManager.removeTaskScheduler(schedule.getWorkerQueueName());
   }
 
   @Test
   public void testMetricAvailable() throws IOException, InterruptedException {
-    assertTrue("TaskScheduler running", taskManager.updateTaskScheduler(schedule));
+    assertTrue(taskManager.updateTaskScheduler(schedule), "TaskScheduler running");
     final MetricRegistry metrics = MetricFactory.getMetrics();
-    assertEquals("There should be 3 gauges in a scheduler.", 3, metrics.getGauges((name, metric) -> name.startsWith("OPS")).size());
+    assertEquals(3, metrics.getGauges((name, metric) -> name.startsWith("OPS")).size(), "There should be 3 gauges in a scheduler.");
   }
 }

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/AbstractRabbitMQTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/AbstractRabbitMQTest.java
@@ -21,9 +21,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
@@ -44,18 +44,18 @@ public class AbstractRabbitMQTest {
   protected MockChannel mockChannel;
   protected AdaptorFactory adapterFactory;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() {
     executor = Executors.newSingleThreadExecutor();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws InterruptedException {
     executor.shutdownNow();
     executor.awaitTermination(10, TimeUnit.MILLISECONDS);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     mockChannel = new MockChannel();
     final ConnectionConfiguration configuration = ConnectionConfiguration.builder()

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandlerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandlerTest.java
@@ -16,12 +16,14 @@
  */
 package nl.aerius.taskmanager.mq;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
 import java.io.IOException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
 
@@ -34,7 +36,8 @@ import nl.aerius.taskmanager.domain.Message;
  */
 public class RabbitMQMessageHandlerTest extends AbstractRabbitMQTest {
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(10000)
   public void testMessageReceivedHandler() throws IOException, InterruptedException {
     final String taskQueueName = "queue1";
     final byte[] receivedBody = "4321".getBytes();
@@ -54,6 +57,6 @@ public class RabbitMQMessageHandlerTest extends AbstractRabbitMQTest {
     });
     mockChannel.basicPublish("", taskQueueName, new BasicProperties(), receivedBody);
     lock.tryAcquire(1, 5, TimeUnit.SECONDS);
-    Assert.assertArrayEquals("Test if body received", receivedBody, data.getData());
+    assertArrayEquals(receivedBody, data.getData(), "Test if body received");
   }
 }

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducerTest.java
@@ -16,12 +16,14 @@
  */
 package nl.aerius.taskmanager.mq;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
 import java.io.IOException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.DefaultConsumer;
@@ -37,7 +39,8 @@ public class RabbitMQWorkerProducerTest extends AbstractRabbitMQTest {
 
   private static final String WORKER_QUEUE_NAME = "TEST";
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5000)
   public void testForwardMessage() throws IOException, InterruptedException {
     final byte[] sendBody = "4321".getBytes();
 
@@ -66,6 +69,6 @@ public class RabbitMQWorkerProducerTest extends AbstractRabbitMQTest {
       }
     });
     lock.tryAcquire(1, 5, TimeUnit.SECONDS);
-    Assert.assertArrayEquals("Test if body send", sendBody, data.getData());
+    assertArrayEquals(sendBody, data.getData(), "Test if body send");
   }
 }


### PR DESCRIPTION
SonarQube seems to require an additional project specifically for reporting.
This project must have the dependencies to the projects to report.
This change adds this project, but only under the profile sonar,
which is only used when running SonarQube.

Changed name in parent pom to show nicely in SonarQube.

Added badges to README

(PR contains PR #13 (Switch to Junit 5) which should be merged first, after which this pr needs to be rebased). PR will only cover [second commit](https://github.com/aerius/taskmanager/commit/447011e83132157301a29df1e7c8a1991ab1adf1) in this pr.