### PR TITLE
Improve logging if RabbitMQ event queue isn't available

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQChannelQueueEventsWatcher.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQChannelQueueEventsWatcher.java
@@ -73,7 +73,7 @@ class RabbitMQChannelQueueEventsWatcher {
       channel.queueBind(q, AMQ_RABBITMQ_EVENT, CHANNEL_PATTERN);
       channel.basicConsume(q, true, createConsumer());
     } catch (final IOException e) {
-      LOG.error("Failed to bind to RabbitMQ event queue. No Queue Event watch not available.");
+      LOG.error("Failed to bind to RabbitMQ event queue. No Queue Event watch not available. Message: {}", e.getMessage());
     }
   }
 


### PR DESCRIPTION
While the event queue is not required the error it throws is an IOException.
This is a rather generic exception and might hide some other edge-cases.
To aid in helping fix potential other errors we should log some extra information.
Logging the stack-trace every time is overkill, so went with printing the message of the exception.