### PR TITLE
Also start consumer on shuthdown initiated by app

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
@@ -100,9 +100,7 @@ class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaDa
 
   @Override
   public void onConsumerShutdown(final ShutdownSignalException sig) {
-    if (!sig.isInitiatedByApplication()) {
-      tryStartConsuming();
-    }
+    tryStartConsuming();
   }
 
   private void tryStartConsuming() {


### PR DESCRIPTION
This shutdown is triggered when an io exception happens and therefor it should restart.
This caused a problem where worker connection was still ok, but consumer connection not. Causing it to give an error on the ack call, closing the consumer with application initiated exception. This caused the consumer to shutdown as it was not restarted after that. This could be seen because in RabbitMQ overview consumers where 0 for these channels and no unacked messages, while there where several messages on the queue.