### PR TITLE
AER-77 Fix handling shutdown of RabbitMQ connection

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/FIFOTaskScheduler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/FIFOTaskScheduler.java
@@ -35,6 +35,11 @@ class FIFOTaskScheduler implements TaskScheduler<PriorityTaskQueue> {
   }
 
   @Override
+  public void killTasks() {
+    tasks.stream().forEach(Task::killTask);
+  }
+
+  @Override
   public Task getNextTask() throws InterruptedException {
     return tasks.take();
   }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/ForwardTaskHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/ForwardTaskHandler.java
@@ -31,4 +31,9 @@ interface ForwardTaskHandler {
    * @param task task to schedule
    */
   void forwardTask(Task task);
+
+  /**
+   * Call to kill all tasks still waiting to be processed.
+   */
+  void killTasks();
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/Task.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/Task.java
@@ -26,6 +26,7 @@ import nl.aerius.taskmanager.domain.MessageMetaData;
 class Task {
   private Message<?> data;
   private final TaskConsumer taskConsumer;
+  private boolean alive = true;
 
   public Task(final TaskConsumer taskConsumer) {
     this.taskConsumer = taskConsumer;
@@ -46,6 +47,14 @@ class Task {
 
   public void setData(final Message<?> data) {
     this.data = data;
+  }
+
+  public void killTask() {
+    this.alive = false;
+  }
+
+  public boolean isAlive() {
+    return alive;
   }
 
   @Override

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskConsumer.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskConsumer.java
@@ -17,6 +17,7 @@
 package nl.aerius.taskmanager;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,13 +36,17 @@ class TaskConsumer implements MessageReceivedHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(TaskConsumer.class);
 
+  private final ExecutorService executorService;
   private final String taskQueueName;
   private final ForwardTaskHandler forwardTaskHandler;
   private final TaskMessageHandler<MessageMetaData, Message<MessageMetaData>> taskMessageHandler;
+
   private boolean running = true;
 
   @SuppressWarnings("unchecked")
-  public TaskConsumer(final String taskQueueName, final ForwardTaskHandler forwardTaskHandler, final AdaptorFactory factory) throws IOException {
+  public TaskConsumer(final ExecutorService executorService, final String taskQueueName, final ForwardTaskHandler forwardTaskHandler,
+      final AdaptorFactory factory) throws IOException {
+    this.executorService = executorService;
     this.taskQueueName = taskQueueName;
     this.forwardTaskHandler = forwardTaskHandler;
     this.taskMessageHandler = factory.createTaskMessageHandler(taskQueueName);
@@ -67,6 +72,12 @@ class TaskConsumer implements MessageReceivedHandler {
       LOG.trace("Task received from {} for worker send to scheduler ({}).", taskQueueName, task.getId());
       forwardTaskHandler.forwardTask(task);
     }
+  }
+
+  @Override
+  public void handleShutdownSignal() {
+    forwardTaskHandler.killTasks();
+    start();
   }
 
   /**
@@ -100,11 +111,13 @@ class TaskConsumer implements MessageReceivedHandler {
   }
 
   public void start() {
-    try {
-      taskMessageHandler.start();
-    } catch (final IOException e) {
-      LOG.error("TaskConsumer for {} got IO problems.", taskQueueName, e);
-    }
+    executorService.submit(() -> {
+      try {
+        taskMessageHandler.start();
+      } catch (final IOException e) {
+        LOG.error("TaskConsumer for {} got IO problems.", taskQueueName, e);
+      }
+    });
   }
 
   /**

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskDispatcher.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskDispatcher.java
@@ -72,10 +72,10 @@ class TaskDispatcher implements ForwardTaskHandler, Runnable {
 
   @Override
   public void killTasks() {
-    // Remove all locks to let RabbitMQ message handlers continue and close shutdown.
-    taskConsumerLocks.forEach((t, s) -> s.release());
     // Tell the scheduler to mark all tasks it tracks to be dead.
     scheduler.killTasks();
+    // Remove all locks to let RabbitMQ message handlers continue and close shutdown.
+    taskConsumerLocks.forEach((t, s) -> s.release());
     LOG.debug("Tasks removed from scheduler {}", workerQueueName);
   }
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskDispatcher.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskDispatcher.java
@@ -17,6 +17,7 @@
 package nl.aerius.taskmanager;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 
@@ -29,12 +30,11 @@ import nl.aerius.taskmanager.exception.NoFreeWorkersException;
 import nl.aerius.taskmanager.exception.TaskAlreadySentException;
 
 /**
- * Control center for processing tasks. Task
+ * Control center for processing tasks.
  */
 class TaskDispatcher implements ForwardTaskHandler, Runnable {
 
   private static final Logger LOG = LoggerFactory.getLogger(TaskDispatcher.class);
-  private static final int NUMBER_CONCURRENT_PREFETCHES = 1;
 
   /**
    * Represents the current state the TaskDispatcher is in.
@@ -43,26 +43,40 @@ class TaskDispatcher implements ForwardTaskHandler, Runnable {
     WAIT_FOR_WORKER, WAIT_FOR_TASK, DISPATCH_TASK;
   }
 
-  private final ConcurrentHashMap<TaskConsumer, Semaphore> taskConsumerLocks = new ConcurrentHashMap<>();
+  private final Map<TaskConsumer, Semaphore> taskConsumerLocks = new ConcurrentHashMap<>();
   private final WorkerPool workerPool;
-  private final TaskScheduler scheduler;
+  private final TaskScheduler<?> scheduler;
 
   private boolean running;
   private State state;
   private final String workerQueueName;
 
-  public TaskDispatcher(final String workerQueueName, final TaskScheduler scheduler, final WorkerPool workerPool) {
+  public TaskDispatcher(final String workerQueueName, final TaskScheduler<?> scheduler, final WorkerPool workerPool) {
     this.workerQueueName = workerQueueName;
     this.scheduler = scheduler;
     this.workerPool = workerPool;
   }
 
+  /**
+   * Forwards task to the scheduler. It allows only one task per taskconsumer to be ready to be scheduled.
+   * To do this it blocks completing this method after passing the task to the scheduler.
+   * Since each taskconsumer runs in it's own thread this blocks per taskconsumer.
+   */
   @Override
   public void forwardTask(final Task task) {
     final TaskConsumer taskConsumer = task.getTaskConsumer();
-    lockClient(taskConsumer);
     scheduler.addTask(task);
     LOG.debug("Task for {} added to scheduler {}", workerQueueName, task.getId());
+    lockClient(taskConsumer);
+  }
+
+  @Override
+  public void killTasks() {
+    // Remove all locks to let RabbitMQ message handlers continue and close shutdown.
+    taskConsumerLocks.forEach((t, s) -> s.release());
+    // Tell the scheduler to mark all tasks it tracks to be dead.
+    scheduler.killTasks();
+    LOG.debug("Tasks removed from scheduler {}", workerQueueName);
   }
 
   /**
@@ -83,7 +97,7 @@ class TaskDispatcher implements ForwardTaskHandler, Runnable {
 
   @Override
   public void run() {
-    Thread.currentThread().setName("TaskDispatcher " + workerQueueName);
+    Thread.currentThread().setName("TaskDispatcher-" + workerQueueName);
     running = true;
     try {
       while (running) {
@@ -93,7 +107,7 @@ class TaskDispatcher implements ForwardTaskHandler, Runnable {
 
         state = State.WAIT_FOR_TASK;
         LOG.debug("Wait for task {}", workerQueueName);
-        final Task task = scheduler.getNextTask();
+        final Task task = getNextTask();
         LOG.debug("Send task to worker {}, ({})", workerQueueName, task.getId());
         state = State.DISPATCH_TASK;
         dispatch(task);
@@ -105,6 +119,14 @@ class TaskDispatcher implements ForwardTaskHandler, Runnable {
       Thread.currentThread().interrupt();
     }
     running = false;
+  }
+
+  private Task getNextTask() throws InterruptedException {
+    Task task;
+    do {
+      task = scheduler.getNextTask();
+    } while (!task.isAlive());
+    return task;
   }
 
   private void dispatch(final Task task) {
@@ -154,7 +176,7 @@ class TaskDispatcher implements ForwardTaskHandler, Runnable {
 
   private void lockClient(final TaskConsumer taskConsumer) {
     try {
-      taskConsumerLocks.computeIfAbsent(taskConsumer, tc -> new Semaphore(NUMBER_CONCURRENT_PREFETCHES)).acquire();
+      taskConsumerLocks.computeIfAbsent(taskConsumer, tc -> new Semaphore(0)).acquire();
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
     }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskManager.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskManager.java
@@ -161,7 +161,7 @@ class TaskManager<T extends TaskQueue, S extends TaskSchedule<T>> {
     public void addTaskConsumerIfAbsent(final String taskQueueName) {
       taskConsumers.computeIfAbsent(taskQueueName, tqn -> {
         try {
-          final TaskConsumer taskConsumer = new TaskConsumer(taskQueueName, dispatcher, factory);
+          final TaskConsumer taskConsumer = new TaskConsumer(executorService, taskQueueName, dispatcher, factory);
           taskConsumer.start();
           LOG.info("Started task queue {}", taskQueueName);
           return taskConsumer;

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskScheduler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskScheduler.java
@@ -36,6 +36,11 @@ interface TaskScheduler<T extends TaskQueue> extends WorkerUpdateHandler {
   void addTask(Task task);
 
   /**
+   * Mark all tasks still waiting to be processed as dead as they can't be processed anymore.
+   */
+  void killTasks();
+
+  /**
    * Returns the next task to process. When no task is present it should wait until a task becomes available.
    * If this method is called it means a worker is available. Therefore the implementation should not be checking
    * something regarding availability of workers.
@@ -70,6 +75,11 @@ interface TaskScheduler<T extends TaskQueue> extends WorkerUpdateHandler {
      */
     TaskScheduler<T> createScheduler(String workerQueueName);
 
+    /**
+     * Returns the handler that persists the scheduler configurations.
+     *
+     * @return handler to read/write scheduler configurations
+     */
     SchedulerFileConfigurationHandler<T, S> getHandler();
   }
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/TaskMessageHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/TaskMessageHandler.java
@@ -79,6 +79,11 @@ public interface TaskMessageHandler<E extends MessageMetaData, M extends Message
      * @param message the message
      */
     void onMessageReceived(Message<?> message);
+
+    /**
+     * Called when the Consumer was shutdown.
+     */
+    void handleShutdownSignal();
   }
 
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/WorkerProducer.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/WorkerProducer.java
@@ -53,10 +53,16 @@ public interface WorkerProducer {
    */
   interface WorkerFinishedHandler {
     /**
-     * Called when worker finished task.
+     * Called when worker finished a task.
      * @param taskId id of the task finished
      */
     void onWorkerFinished(String taskId);
+
+    /**
+     * Instruct the handler to reset; that means all tasks that are waiting to be finished will never be marked as finished and therefor should
+     * be cleaned up.
+     */
+    void reset();
   }
 
   /**

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQAdaptorFactory.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQAdaptorFactory.java
@@ -56,6 +56,6 @@ public class RabbitMQAdaptorFactory implements AdaptorFactory {
 
   @Override
   public WorkerProducer createWorkerProducer(final String workerQueueName) {
-    return new RabbitMQWorkerProducer(factory, workerQueueName);
+    return new RabbitMQWorkerProducer(executorService, factory, workerQueueName);
   }
 }

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/PriorityTaskSchedulerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/PriorityTaskSchedulerTest.java
@@ -273,7 +273,7 @@ class PriorityTaskSchedulerTest {
   }
 
   private TaskConsumer createMockTaskConsumer(final String taskQueueName) throws IOException {
-    return new TaskConsumer(taskQueueName, mock(ForwardTaskHandler.class), new MockAdaptorFactory()) {
+    return new TaskConsumer(mock(ExecutorService.class), taskQueueName, mock(ForwardTaskHandler.class), new MockAdaptorFactory()) {
       @Override
       public void messageDelivered(final MessageMetaData messageMetaData) {
         //no-op.

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/WorkerPoolTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/WorkerPoolTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -56,7 +57,7 @@ class WorkerPoolTest {
       }
     };
     workerPool = new WorkerPool(WORKER_QUEUE_NAME_TEST, new MockWorkerProducer(), workerUpdateHandler);
-    taskConsumer = new TaskConsumer("testqueue", mock(ForwardTaskHandler.class), new MockAdaptorFactory()) {
+    taskConsumer = new TaskConsumer(mock(ExecutorService.class), "testqueue", mock(ForwardTaskHandler.class), new MockAdaptorFactory()) {
       @Override
       public void messageDelivered(final MessageMetaData message) {
         WorkerPoolTest.this.message = (RabbitMQMessageMetaData) message;

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandlerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandlerTest.java
@@ -53,6 +53,11 @@ class RabbitMQMessageHandlerTest extends AbstractRabbitMQTest {
         }
         lock.release(1);
       }
+
+      @Override
+      public void handleShutdownSignal() {
+        // No-op
+      }
     });
     mockChannel.basicPublish("", taskQueueName, new BasicProperties(), receivedBody);
     lock.tryAcquire(1, 5, TimeUnit.SECONDS);


### PR DESCRIPTION
When the RabbitMQ connection shuts down the tasks tracked in the Task Manager will be zombies as they will not be reported back by the workers as to be finished because due to the connection loss they will be put back on the queue.
Therefor when the connection loss happens the Task Manager should clean up internally all tasks it tracks and restart connections and wait for the tasks to re-appear. This is done by marking all tasks as not being alive. The TaskDispatcher will than ignore all dead tasks.

Changed that TaskDispatcher forwardTask locks after setting task on the scheduler.
Before it claimed a lock, put on the scheduler and returned. Then when the next task was retrieved from the queue and the task was forwarded it locked at that point.
This was changed because when all tasks are killed we now know that no tasks are halfway in the forwardTask method.
Because previous when tasks where killed, the task waiting in the forwardTask method could passed on to the scheduler when kill was in action due to timing issues.