### PR TITLE
AER-274 Make taskmanager configurable via environment

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/PriorityTaskSchedulerFileHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/PriorityTaskSchedulerFileHandler.java
@@ -22,6 +22,10 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Locale;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -34,20 +38,42 @@ import nl.aerius.taskmanager.domain.PriorityTaskSchedule;
  */
 class PriorityTaskSchedulerFileHandler implements SchedulerFileConfigurationHandler<PriorityTaskQueue, PriorityTaskSchedule> {
 
-  private static final String PREFIX = "priority-task-scheduler.";
+  private static final Logger LOG = LoggerFactory.getLogger(PriorityTaskSchedulerFileHandler.class);
+
+  private static final String FILE_PREFIX = "priority-task-scheduler.";
+  private static final String ENV_PREFIX = "AERIUS_PRIORITY_TASK_SCHEDULER_";
 
   private final Gson gson = new GsonBuilder().setPrettyPrinting().excludeFieldsWithoutExposeAnnotation().create();
 
   @Override
   public PriorityTaskSchedule read(final File file) throws IOException {
+    final PriorityTaskSchedule fileSchedule = readFromFile(file);
+    final PriorityTaskSchedule environmentSchedule = readFromEnvironment(fileSchedule.getWorkerQueueName());
+    if (environmentSchedule != null) {
+      return environmentSchedule;
+    }
+    return fileSchedule;
+  }
+
+  private PriorityTaskSchedule readFromFile(final File file) throws IOException {
     try (final Reader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
       return gson.fromJson(reader, PriorityTaskSchedule.class);
     }
   }
 
+  private PriorityTaskSchedule readFromEnvironment(final String workerQueueName) {
+    final String environmentKey = ENV_PREFIX + workerQueueName.toUpperCase(Locale.ROOT);
+    final String environmentValue = System.getenv(environmentKey);
+    if (environmentValue != null) {
+      LOG.info("Using configuration for worker queue {} from environment", workerQueueName);
+      return gson.fromJson(environmentValue, PriorityTaskSchedule.class);
+    }
+    return null;
+  }
+
   @Override
   public void write(final File path, final PriorityTaskSchedule priorityTaskSchedule) throws IOException {
-    final File targetFile = new File(path, PREFIX + priorityTaskSchedule.getWorkerQueueName() + ".json");
+    final File targetFile = new File(path, FILE_PREFIX + priorityTaskSchedule.getWorkerQueueName() + ".json");
     try (final Writer writer = Files.newBufferedWriter(targetFile.toPath(), StandardCharsets.UTF_8)) {
       writer.write(gson.toJson(priorityTaskSchedule));
     }


### PR DESCRIPTION
At this point, the task manager gets its configuration from files. As soon as there is a configuration change in one of these files, the task manager will automatically reload its configuration. Modifying files is just not very useful in Docker / containers, it is better to modify it via environment variables, so that it is also possible to easily adapt these per environment. That is more consistent compared to other configuration options in AERIUS.

The configuration will remain in the files. If an environment variable exists for a particular worker type, the settings will be overwritten by this configuration. The value in the environment variable takes precedence over the value in the file.