### PR TITLE
AER-274 Make taskmanager configurable via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ A higher number means a higher priority.
 For example if the value is `0.6` and there are `10` workers.
 This would mean a maximum of `6` workers will be given a tasks from this queue.
 
+### Overriding queue configuration
+Queue configuration for a specific worker can be overridden by creating an environment variable.
+When an environment variable exists with a matching worker queue name, that configuration is used instead of the file.
+
+```
+AERIUS_PRIORITY_TASK_SCHEDULER_{WORKER QUEUE NAME} = {
+  "workerQueueName": "<type of the queue>",
+  "queues": [...]
+}
+```
+
 ## Building the Task Manager
 
 To build the task manager java and maven are needed.

--- a/source/README.md
+++ b/source/README.md
@@ -2,6 +2,7 @@
 
 The image requires queue configuration to be available at `/app/queue`.
 This can be done by using `volumes` or by extending the image and adding the files to the image.
+Queue configuration can be overridden by using an environment variable.
 
 ##### ENV variables that are required or set by default for convenience
 
@@ -9,6 +10,7 @@ This can be done by using `volumes` or by extending the image and adding the fil
 - `AERIUS_BROKER_PORT`: Defaults to `5672`.
 - `AERIUS_BROKER_USERNAME`: Defaults to `aerius`.
 - `AERIUS_BROKER_PASSWORD`: Defaults to `aerius`.
+- `AERIUS_PRIORITY_TASK_SCHEDULER_{WORKER QUEUE NAME}`: Overrides the queue configuration for a specific worker. Defaults to the configuration in the files.
 
 ##### Example build
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/PriorityTaskSchedulerFileHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/PriorityTaskSchedulerFileHandler.java
@@ -49,10 +49,7 @@ class PriorityTaskSchedulerFileHandler implements SchedulerFileConfigurationHand
   public PriorityTaskSchedule read(final File file) throws IOException {
     final PriorityTaskSchedule fileSchedule = readFromFile(file);
     final PriorityTaskSchedule environmentSchedule = readFromEnvironment(fileSchedule.getWorkerQueueName());
-    if (environmentSchedule != null) {
-      return environmentSchedule;
-    }
-    return fileSchedule;
+    return environmentSchedule == null ? fileSchedule : environmentSchedule;
   }
 
   private PriorityTaskSchedule readFromFile(final File file) throws IOException {

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/PriorityTaskSchedulerFileHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/PriorityTaskSchedulerFileHandler.java
@@ -22,6 +22,10 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Locale;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -34,20 +38,42 @@ import nl.aerius.taskmanager.domain.PriorityTaskSchedule;
  */
 class PriorityTaskSchedulerFileHandler implements SchedulerFileConfigurationHandler<PriorityTaskQueue, PriorityTaskSchedule> {
 
-  private static final String PREFIX = "priority-task-scheduler.";
+  private static final Logger LOG = LoggerFactory.getLogger(PriorityTaskSchedulerFileHandler.class);
+
+  private static final String FILE_PREFIX = "priority-task-scheduler.";
+  private static final String ENV_PREFIX = "AERIUS_PRIORITY_TASK_SCHEDULER_";
 
   private final Gson gson = new GsonBuilder().setPrettyPrinting().excludeFieldsWithoutExposeAnnotation().create();
 
   @Override
   public PriorityTaskSchedule read(final File file) throws IOException {
+    final PriorityTaskSchedule fileSchedule = readFromFile(file);
+    final PriorityTaskSchedule environmentSchedule = readFromEnvironment(fileSchedule.getWorkerQueueName());
+    if (environmentSchedule != null) {
+      return environmentSchedule;
+    }
+    return fileSchedule;
+  }
+
+  private PriorityTaskSchedule readFromFile(final File file) throws IOException {
     try (final Reader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
       return gson.fromJson(reader, PriorityTaskSchedule.class);
     }
   }
 
+  private PriorityTaskSchedule readFromEnvironment(final String workerQueueName) {
+    final String environmentKey = ENV_PREFIX + workerQueueName.toUpperCase(Locale.ROOT);
+    final String environmentValue = System.getenv(environmentKey);
+    if (environmentValue != null) {
+      LOG.info("Using configuration for worker queue {} from environment", workerQueueName);
+      return gson.fromJson(environmentValue, PriorityTaskSchedule.class);
+    }
+    return null;
+  }
+
   @Override
   public void write(final File path, final PriorityTaskSchedule priorityTaskSchedule) throws IOException {
-    final File targetFile = new File(path, PREFIX + priorityTaskSchedule.getWorkerQueueName() + ".json");
+    final File targetFile = new File(path, FILE_PREFIX + priorityTaskSchedule.getWorkerQueueName() + ".json");
     try (final Writer writer = Files.newBufferedWriter(targetFile.toPath(), StandardCharsets.UTF_8)) {
       writer.write(gson.toJson(priorityTaskSchedule));
     }


### PR DESCRIPTION
At this point, the task manager gets its configuration from files. As soon as there is a configuration change in one of these files, the task manager will automatically reload its configuration. Modifying files is just not very useful in Docker / containers, it is better to modify it via environment variables, so that it is also possible to easily adapt these per environment. That is more consistent compared to other configuration options in AERIUS.

The configuration will remain in the files. If an environment variable exists for a particular worker type, the settings will be overwritten by this configuration. The value in the environment variable takes precedence over the value in the file.