### PR TITLE
AER3-347 Made `RabbitMQWorkerMonitor` observers synchronized.

### DIFF
--- a/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/mq/RabbitMQWorkerMonitor.java
+++ b/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/mq/RabbitMQWorkerMonitor.java
@@ -81,7 +81,9 @@ public class RabbitMQWorkerMonitor {
    * @param observer observer to add
    */
   public void addObserver(final RabbitMQWorkerObserver observer) {
-    observers.add(observer);
+    synchronized (observers) {
+      observers.add(observer);
+    }
   }
 
   /**
@@ -90,7 +92,9 @@ public class RabbitMQWorkerMonitor {
    * @param observer observer to remove
    */
   public void removeObserver(final RabbitMQWorkerObserver observer) {
-    observers.remove(observer);
+    synchronized (observers) {
+      observers.remove(observer);
+    }
   }
 
   /**
@@ -142,7 +146,9 @@ public class RabbitMQWorkerMonitor {
     final int workerSize = getParamInt(headers, HEADER_PARAM_WORKER_SIZE, -1);
     final int utilisationSize = getParamInt(headers, HEADER_PARAM_UTILISATION, -1);
 
-    observers.forEach(ro -> ro.updateWorkers(queueName, workerSize, utilisationSize));
+    synchronized (observers) {
+      observers.forEach(ro -> ro.updateWorkers(queueName, workerSize, utilisationSize));
+    }
   }
 
   /**


### PR DESCRIPTION
As it was, in some cases the consumer channel for RabbitMQWorkerMonitor crashes because the ArrayList containing the observers is changed during an incoming message (`forEach` in `handleDelivery` would then encounter an NPE). This would cause the consumer channel to close, getting calculations stuck.