### PR TITLE
Made it possible to make certain schedules durable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ The parameter `workerQueueName` is required and should match the name related to
 The task manager derives the full worker queue name from it.
 So `ops` becomes the worker queue name: `aerius.worker.ops`.
 
-The parameter `durable` indicates if the worker queue and related client queues should be created persistent.
-Some queues have derived data on the queue.
-This means if the RabbitMQ server goes down the original task that created the data on non persistent queues is recreated.
-Therefore it's not a problem the data on the non persistent queues is lost due to the RabbitMQ server shutdown.
-It will actually help, because that data can't be used anyway, because the original task is restarted also.
+The parameter `durable` indicates if the worker queue and related client queues should be created with the `durable` or non-`durable` flag (defaults to `durable`).
+If a queue is made `durable` and the RabbitMQ server goes down, the queue and it's messages will be restored after startup.
+Some queues can have derived messages on the queue, that are recreated by the parent task after a RabbitMQ shutdown.
+For these queues it would make sense to not make them durable.
+RabbitMQ will require less storage space/IOPS and be faster as it won't need to depend on disk I/O for these queues.
 
 In `queues` there can be 1 or more queue configurations.
 Each queue configuration consists of 3 parameters:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The json format of the configuration files is as follows:
 ```
 {
   "workerQueueName": "<type of the queue>",
+  "durable" : <true|false>
   "queues": [
     {
       "queueName": "<client queue name>",
@@ -100,6 +101,12 @@ The json format of the configuration files is as follows:
 The parameter `workerQueueName` is required and should match the name related to the worker.
 The task manager derives the full worker queue name from it.
 So `ops` becomes the worker queue name: `aerius.worker.ops`.
+
+The parameter `durable` indicates if the worker queue and related client queues should be created persistent.
+Some queues have derived data on the queue.
+This means if the RabbitMQ server goes down the original task that created the data on non persistent queues is recreated.
+Therefore it's not a problem the data on the non persistent queues is lost due to the RabbitMQ server shutdown.
+It will actually help, because that data can't be used anyway, because the original task is restarted also.
 
 In `queues` there can be 1 or more queue configurations.
 Each queue configuration consists of 3 parameters:

--- a/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/TaskManagerClientSender.java
+++ b/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/TaskManagerClientSender.java
@@ -172,10 +172,6 @@ public class TaskManagerClientSender implements TaskWrapperSender {
         // Create a channel to send the message over.
         final Channel channel = getConnection().createChannel();
         final String queueName = wrapper.getNaming().getTaskQueueName(wrapper.getQueueName());
-        // create a consumer and let it listen to a reply queue.
-        // Ensure a queue is available.
-        channel.queueDeclare(queueName, QUEUE_DURABLE, QUEUE_EXCLUSIVE, QUEUE_AUTO_DELETE, null);
-        // send the task.
         final Serializable task = wrapper.getTask();
         // set a unique message ID.
         final String messageId = wrapper.getTaskId();

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskConsumer.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskConsumer.java
@@ -44,12 +44,12 @@ class TaskConsumer implements MessageReceivedHandler {
   private boolean running = true;
 
   @SuppressWarnings("unchecked")
-  public TaskConsumer(final ExecutorService executorService, final String taskQueueName, final ForwardTaskHandler forwardTaskHandler,
-      final AdaptorFactory factory) throws IOException {
+  public TaskConsumer(final ExecutorService executorService, final String taskQueueName, final boolean durable,
+      final ForwardTaskHandler forwardTaskHandler, final AdaptorFactory factory) throws IOException {
     this.executorService = executorService;
     this.taskQueueName = taskQueueName;
     this.forwardTaskHandler = forwardTaskHandler;
-    this.taskMessageHandler = factory.createTaskMessageHandler(taskQueueName);
+    this.taskMessageHandler = factory.createTaskMessageHandler(taskQueueName, durable);
     taskMessageHandler.addMessageReceivedHandler(this);
   }
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/AdaptorFactory.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/AdaptorFactory.java
@@ -32,15 +32,17 @@ public interface AdaptorFactory {
   /**
    * Creates a new worker producer for the given worker type.
    * @param workerQueueName name of queue of the worker
+   * @param durable true if the queue created should be persistent during server restart
    * @return new worker producer object
    */
-  WorkerProducer createWorkerProducer(String workerQueueName);
+  WorkerProducer createWorkerProducer(String workerQueueName, boolean durable);
 
   /**
    * Creates a new TaksMessageHandler for the given worker type and queue.
    * @param taskQueueName queue name
+   * @param durable true if the queue created should be persistent during server restart
    * @return new TaksMessageHandler object
    * @throws IOException error in case or connection problems
    */
-  TaskMessageHandler createTaskMessageHandler(String taskQueueName) throws IOException;
+  TaskMessageHandler createTaskMessageHandler(String taskQueueName, boolean durable) throws IOException;
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/TaskSchedule.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/TaskSchedule.java
@@ -31,6 +31,9 @@ public class TaskSchedule<T extends TaskQueue> {
   private String workerQueueName;
 
   @Expose
+  private boolean durable;
+
+  @Expose
   private List<T> queues = new ArrayList<>();
 
   public String getWorkerQueueName() {
@@ -47,5 +50,13 @@ public class TaskSchedule<T extends TaskQueue> {
 
   public void setTaskConfigurations(final List<T> taskConfigurations) {
     this.queues = taskConfigurations;
+  }
+
+  public void setDurable(final boolean durable) {
+    this.durable = durable;
+  }
+
+  public boolean isDurable() {
+    return durable;
   }
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQAdaptorFactory.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQAdaptorFactory.java
@@ -45,8 +45,8 @@ public class RabbitMQAdaptorFactory implements AdaptorFactory {
   }
 
   @Override
-  public TaskMessageHandler createTaskMessageHandler(final String taskQueueName) throws IOException {
-    return new RabbitMQMessageHandler(factory, taskQueueName);
+  public TaskMessageHandler createTaskMessageHandler(final String taskQueueName, final boolean durable) throws IOException {
+    return new RabbitMQMessageHandler(factory, taskQueueName, durable);
   }
 
   @Override
@@ -55,7 +55,7 @@ public class RabbitMQAdaptorFactory implements AdaptorFactory {
   }
 
   @Override
-  public WorkerProducer createWorkerProducer(final String workerQueueName) {
-    return new RabbitMQWorkerProducer(executorService, factory, workerQueueName);
+  public WorkerProducer createWorkerProducer(final String workerQueueName, final boolean durable) {
+    return new RabbitMQWorkerProducer(executorService, factory, workerQueueName, durable);
   }
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageConsumer.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageConsumer.java
@@ -44,10 +44,12 @@ class RabbitMQMessageConsumer extends DefaultConsumer {
 
   private final String queueName;
   private final ConsumerCallback callback;
+  private final boolean durable;
 
-  RabbitMQMessageConsumer(final Channel channel, final String queueName, final ConsumerCallback callback) {
+  RabbitMQMessageConsumer(final Channel channel, final String queueName, final boolean durable, final ConsumerCallback callback) {
     super(channel);
     this.queueName = queueName;
+    this.durable = durable;
     this.callback = callback;
   }
 
@@ -55,7 +57,7 @@ class RabbitMQMessageConsumer extends DefaultConsumer {
     LOG.debug("Starting consumer {}.", queueName);
     final Channel taskChannel = getChannel();
     // ensure a durable channel exists
-    taskChannel.queueDeclare(queueName, true, false, false, null);
+    taskChannel.queueDeclare(queueName, durable, false, false, null);
     //ensure only one message gets delivered at a time.
     taskChannel.basicQos(1);
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
@@ -42,6 +42,7 @@ class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaDa
 
   private final BrokerConnectionFactory factory;
   private final String taskQueueName;
+  private final boolean durable;
 
   private MessageReceivedHandler messageReceivedHandler;
   private RabbitMQMessageConsumer consumer;
@@ -51,16 +52,19 @@ class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaDa
    */
   private final AtomicBoolean tryConnecting = new AtomicBoolean();
 
+
   /**
    * Constructor.
    *
    * @param factory the factory to get the a RabbitMQ connection from
    * @param taskQueueName the name of the task queue
+   * @param durable if true the queue will be created persistent
    * @throws IOException
    */
-  public RabbitMQMessageHandler(final BrokerConnectionFactory factory, final String taskQueueName) throws IOException {
+  public RabbitMQMessageHandler(final BrokerConnectionFactory factory, final String taskQueueName, final boolean durable) throws IOException {
     this.factory = factory;
     this.taskQueueName = taskQueueName;
+    this.durable = durable;
   }
 
   @Override
@@ -138,6 +142,7 @@ class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaDa
       consumer = new RabbitMQMessageConsumer(
           factory.getConnection().createChannel(),
           taskQueueName,
+          durable,
           this);
       consumer.getChannel().addShutdownListener(e -> handleShutdownSignal(e));
       consumer.startConsuming();

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockAdaptorFactory.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockAdaptorFactory.java
@@ -39,12 +39,12 @@ public class MockAdaptorFactory implements AdaptorFactory {
   }
 
   @Override
-  public WorkerProducer createWorkerProducer(final String workerQueueName) {
+  public WorkerProducer createWorkerProducer(final String workerQueueName, final boolean durable) {
     return mockWorkerProducer;
   }
 
   @Override
-  public TaskMessageHandler createTaskMessageHandler(final String taskQueueName) throws IOException {
+  public TaskMessageHandler createTaskMessageHandler(final String taskQueueName, final boolean durable) throws IOException {
     return mockTaskMessageHandler;
   }
 

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/PriorityTaskSchedulerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/PriorityTaskSchedulerTest.java
@@ -273,7 +273,7 @@ class PriorityTaskSchedulerTest {
   }
 
   private TaskConsumer createMockTaskConsumer(final String taskQueueName) throws IOException {
-    return new TaskConsumer(mock(ExecutorService.class), taskQueueName, mock(ForwardTaskHandler.class), new MockAdaptorFactory()) {
+    return new TaskConsumer(mock(ExecutorService.class), taskQueueName, false, mock(ForwardTaskHandler.class), new MockAdaptorFactory()) {
       @Override
       public void messageDelivered(final MessageMetaData messageMetaData) {
         //no-op.

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskDispatcherTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskDispatcherTest.java
@@ -58,7 +58,7 @@ class TaskDispatcherTest {
     workerPool = new WorkerPool(WORKER_QUEUE_NAME_TEST, workerProducer, scheduler);
     dispatcher = new TaskDispatcher(WORKER_QUEUE_NAME_TEST, scheduler, workerPool);
     factory = new MockAdaptorFactory();
-    taskConsumer = new TaskConsumer(executor, "testqueue", dispatcher, factory);
+    taskConsumer = new TaskConsumer(executor, "testqueue", false, dispatcher, factory);
   }
 
   @AfterEach

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/WorkerPoolTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/WorkerPoolTest.java
@@ -57,7 +57,7 @@ class WorkerPoolTest {
       }
     };
     workerPool = new WorkerPool(WORKER_QUEUE_NAME_TEST, new MockWorkerProducer(), workerUpdateHandler);
-    taskConsumer = new TaskConsumer(mock(ExecutorService.class), "testqueue", mock(ForwardTaskHandler.class), new MockAdaptorFactory()) {
+    taskConsumer = new TaskConsumer(mock(ExecutorService.class), "testqueue", false, mock(ForwardTaskHandler.class), new MockAdaptorFactory()) {
       @Override
       public void messageDelivered(final MessageMetaData message) {
         WorkerPoolTest.this.message = (RabbitMQMessageMetaData) message;

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandlerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandlerTest.java
@@ -41,7 +41,7 @@ class RabbitMQMessageHandlerTest extends AbstractRabbitMQTest {
   void testMessageReceivedHandler() throws IOException, InterruptedException {
     final String taskQueueName = "queue1";
     final byte[] receivedBody = "4321".getBytes();
-    final TaskMessageHandler tmh = adapterFactory.createTaskMessageHandler(taskQueueName);
+    final TaskMessageHandler tmh = adapterFactory.createTaskMessageHandler(taskQueueName, false);
     final Semaphore lock = new Semaphore(0);
     final DataDock data = new DataDock();
     tmh.start();

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducerTest.java
@@ -47,7 +47,7 @@ class RabbitMQWorkerProducerTest extends AbstractRabbitMQTest {
   void testForwardMessage() throws IOException, InterruptedException {
     final byte[] sendBody = "4321".getBytes();
 
-    final WorkerProducer wp = adapterFactory.createWorkerProducer(WORKER_QUEUE_NAME);
+    final WorkerProducer wp = adapterFactory.createWorkerProducer(WORKER_QUEUE_NAME, false);
     wp.start();
     final BasicProperties bp = new BasicProperties();
     wp.forwardMessage(new RabbitMQMessage(WORKER_QUEUE_NAME, null, 4321, bp, sendBody) {


### PR DESCRIPTION
Don't declare queues in the clients. The taskmanager should do this
This is because the taskmanager knows if the queue should be created durable or not.