### PR TITLE
Fix concurrent modification error when adding new configuration

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQWorkerSizeProvider.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQWorkerSizeProvider.java
@@ -17,6 +17,7 @@
 package nl.aerius.taskmanager.mq;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -100,7 +101,7 @@ public class RabbitMQWorkerSizeProvider implements WorkerSizeProviderProxy {
 
   @Override
   public void shutdown() {
-    for (final String key : observers.keySet()) {
+    for (final String key : new ArrayList<>(observers.keySet())) {
       removeObserver(key);
     }
     eventProducer.shutdown();


### PR DESCRIPTION
When adding a new configuration file to the directory the taskmanger failed with a concurrent modification error because it tried to remove an observer from the map it was iterating over. Apparently using keySet still keeps a reference to the map. Therefore it's wrapped by a new list.