### PR TITLE
Update version to 1.5.0

### DIFF
--- a/source/pom.xml
+++ b/source/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>nl.aerius</groupId>
   <artifactId>taskmanager-parent</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>1.5.0</version>
   <packaging>pom</packaging>
   <name>Taskmanager</name>
   <url>https://www.aerius.nl</url>

--- a/source/taskmanager-client/pom.xml
+++ b/source/taskmanager-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>taskmanager-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.5.0</version>
   </parent>
 
   <artifactId>taskmanager-client</artifactId>

--- a/source/taskmanager-report/pom.xml
+++ b/source/taskmanager-report/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>taskmanager-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.5.0</version>
   </parent>
 
   <artifactId>taskmanager-report</artifactId>

--- a/source/taskmanager-test/pom.xml
+++ b/source/taskmanager-test/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>taskmanager-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.5.0</version>
   </parent>
 
   <artifactId>taskmanager-test</artifactId>

--- a/source/taskmanager/pom.xml
+++ b/source/taskmanager/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>taskmanager-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.5.0</version>
   </parent>
 
   <artifactId>taskmanager</artifactId>


### PR DESCRIPTION
Because this version contains a change that will make the messages on the queue incompatible with an earlier version.