### PR TITLE
Avoid using executorservice to start reply consumer

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQAdaptorFactory.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQAdaptorFactory.java
@@ -56,6 +56,6 @@ public class RabbitMQAdaptorFactory implements AdaptorFactory {
 
   @Override
   public WorkerProducer createWorkerProducer(final String workerQueueName, final boolean durable) {
-    return new RabbitMQWorkerProducer(executorService, factory, workerQueueName, durable);
+    return new RabbitMQWorkerProducer(factory, workerQueueName, durable);
   }
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducer.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducer.java
@@ -19,7 +19,6 @@ package nl.aerius.taskmanager.mq;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -48,7 +47,6 @@ class RabbitMQWorkerProducer implements WorkerProducer {
 
   private static final int DEFAULT_RETRY_SECONDS = 10;
 
-  private final ScheduledExecutorService executorService;
   private final BrokerConnectionFactory factory;
   private final String workerQueueName;
 
@@ -56,9 +54,8 @@ class RabbitMQWorkerProducer implements WorkerProducer {
   private boolean isShutdown;
   private final boolean durable;
 
-  public RabbitMQWorkerProducer(final ScheduledExecutorService executorService, final BrokerConnectionFactory factory, final String workerQueueName,
+  public RabbitMQWorkerProducer(final BrokerConnectionFactory factory, final String workerQueueName,
       final boolean durable) {
-    this.executorService = executorService;
     this.factory = factory;
     this.workerQueueName = workerQueueName;
     this.durable = durable;
@@ -71,7 +68,7 @@ class RabbitMQWorkerProducer implements WorkerProducer {
 
   @Override
   public void start() {
-    executorService.schedule(this::tryStartReplyConsumer, DEFAULT_RETRY_SECONDS, TimeUnit.SECONDS);
+    tryStartReplyConsumer();
   }
 
   @Override


### PR DESCRIPTION
As it was, the reply consumer wouldn't be started until 10 seconds have passed (the DEFAULT_RETRY_SECONDS as used here is actually a DELAY_SECONDS...). Because we don't want to start the actual queue consumer before the reply consumer has been started, it doesn't make sense to use an executorService: this shouldn't be started asynchronously. This should fix some issues where a task was handled before the reply queue was actually created, which in turn would cause the taskmanager to never get a signal that the task was finished.