### PR TITLE
Generic improvements

### DIFF
--- a/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/TaskManagerClientSender.java
+++ b/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/TaskManagerClientSender.java
@@ -120,9 +120,8 @@ public class TaskManagerClientSender implements TaskWrapperSender {
     }
     boolean done = false;
     while (running && !done) {
-      try {
+      try (final Channel channel = getConnection().createChannel()) {
         // Create a channel to send the message over.
-        final Channel channel = getConnection().createChannel();
         final String queueName = wrapper.getNaming().getTaskQueueName(wrapper.getQueueName());
         final Serializable task = wrapper.getTask();
         // set a unique message ID.
@@ -140,8 +139,6 @@ public class TaskManagerClientSender implements TaskWrapperSender {
         final BasicProperties props = builder.build();
         // Send the message to the taskmanager.
         channel.basicPublish("", queueName, props, QueueHelper.objectToBytes(task));
-        // Close this channel.
-        channel.close();
         // task has been send successfully, return.
         done = true;
       } catch (final ConnectException | TimeoutException e) {

--- a/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/TaskManagerClientSender.java
+++ b/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/TaskManagerClientSender.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.ConnectException;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import org.slf4j.Logger;
@@ -71,53 +70,6 @@ public class TaskManagerClientSender implements TaskWrapperSender {
     }
     this.factory = factory;
     factory.registerClient(this);
-  }
-
-  /**
-   * Convenience method of {@link #sendTask(Serializable, String, TaskResultCallback, WorkerQueueType, String)}.
-   * Should be used when results are not important and should not be waited for.
-   *
-   * @param input The input object which the worker needs to do the work.
-   * @param queueNaming name of the queue
-   * @param taskQueueName The name of the queue on which this task should be placed (should be known in taskmanager).
-   * @throws IOException In case of errors communicating with queue.
-   */
-  public void sendTask(final Serializable input, final WorkerQueueType queueNaming, final String taskQueueName) throws IOException {
-    final String uniqueId = UUID.randomUUID().toString();
-    sendTask(input, uniqueId, queueNaming, taskQueueName);
-  }
-
-  /**
-   * Convenience method of {@link #sendTask(Serializable, String, TaskResultCallback, WorkerQueueType, String)}.
-   * Should be used when results are not important and should not be waited for.
-   *
-   * @param input The input object which the worker needs to do the work.
-   * @param uniqueId The unique ID to use for this task. Can be used in worker to link results to this task
-   * @param queueNaming name of the queue
-   * @param taskQueueName The name of the queue on which this task should be placed (should be known in taskmanager).
-   * @throws IOException In case of errors communicating with queue.
-   */
-  public void sendTask(final Serializable input, final String uniqueId, final WorkerQueueType queueNaming, final String taskQueueName)
-      throws IOException {
-    sendTask(new TaskWrapper(Optional.empty(), input, uniqueId, uniqueId, taskQueueName, queueNaming));
-  }
-
-  /**
-   * Convenience method of {@link #sendTask(Serializable, String, TaskResultCallback, WorkerQueueType, String)}.
-   *
-   * @param input The input object which the worker needs to do the work.
-   * @param resultCallback The resultCallback which will receive results. Can be null, in which case the messages are only send and no results can be
-   *          retrieved.
-   * @param queueNaming name of the queue
-   * @param taskQueueName The name of the queue on which this task should be placed (should be known in taskmanager).
-   * @return a random unique task ID. Will be used when a result is received to tell the TaskResultCallback which task was the cause.
-   * @throws IOException In case of errors communicating with queue.
-   */
-  public String sendTask(final Serializable input, final TaskResultCallback resultCallback, final WorkerQueueType queueNaming,
-      final String taskQueueName) throws IOException {
-    final String uniqueId = UUID.randomUUID().toString();
-    sendTask(input, uniqueId, resultCallback, queueNaming, taskQueueName);
-    return uniqueId;
   }
 
   /**

--- a/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/WorkerQueueType.java
+++ b/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/WorkerQueueType.java
@@ -68,7 +68,7 @@ public class WorkerQueueType {
    * @return The queuename that should be used for declaring the queue.
    */
   public String getTaskQueueName(final String taskName) {
-    return NAMING_PREFIX + propertyName() + DOT + taskName;
+    return taskName == null ? null : (NAMING_PREFIX + propertyName() + DOT + taskName);
   }
 
   public String getWorkerQueueName() {

--- a/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/WorkerResultSender.java
+++ b/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/WorkerResultSender.java
@@ -57,7 +57,11 @@ public class WorkerResultSender implements WorkerIntermediateResultSender {
   public void sendFinalResult(final Serializable data) throws IOException {
     sendIntermediateResult(data);
     if (properties.getHeaders() != null) {
-      sendMessage(QueueHelper.getHeaderString(properties, QueueConstants.TASKMANAGER_REPLY_QUEUE), EMPTY_ARRAY);
+      final String taskManagerReplyQueue = QueueHelper.getHeaderString(properties, QueueConstants.TASKMANAGER_REPLY_QUEUE);
+
+      if (taskManagerReplyQueue != null) {
+        sendMessage(taskManagerReplyQueue, EMPTY_ARRAY);
+      }
     }
   }
 
@@ -70,5 +74,4 @@ public class WorkerResultSender implements WorkerIntermediateResultSender {
     // reply to the requested queue, converting the object to bytes first.
     channel.basicPublish(EXCHANGE, queue, basicProperties, data);
   }
-
 }

--- a/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/TaskManagerClientTest.java
+++ b/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/TaskManagerClientTest.java
@@ -196,7 +196,7 @@ class TaskManagerClientTest {
    */
   @Test
   void testSendTaskWithoutResultHandler() throws IOException {
-    taskManagerClient.sendTask(new MockTaskInput(), workerType, TASK_QUEUE_NAME);
+    taskManagerClient.sendTask(new MockTaskInput(), UUID.randomUUID().toString(), null, workerType, TASK_QUEUE_NAME);
     assertTrue(taskManagerClient.isUsable(), "Taskmanagerclient should still be usable.");
   }
 


### PR DESCRIPTION
* Added sendTask to directly send tasks to a worker queue. Kept it backward compatible. Thus current usages still work as expected.
* Use try-with-resources for channel creation. Instead of close at the end.
* Only reply to taskmanager worker queue if replyCC is set
* null pointer safety check on getTaskQueueName. If passed taskName is null it should just return null.
* Removed obsolete sendTask methods from TaskManagerCLientSender. Moved the single use by a unit test to let the unit test use the generic method.