### PR TITLE
AER-2293 - Attempt to reduce error log when restarting taskmanager

### DIFF
--- a/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/BrokerConnectionFactory.java
+++ b/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/BrokerConnectionFactory.java
@@ -86,28 +86,28 @@ public class BrokerConnectionFactory {
   }
 
   private Connection openConnection() {
-    Connection connection = null;
+    Connection localConnection = null;
     boolean retry = true;
     int retryTime = 0;
 
     while (retry) {
       retryTime += WAIT_BEFORE_RETRY_SECONDS;
       try {
-        connection = createNewConnection();
+        localConnection = createNewConnection();
         retry = false;
       } catch (final IOException | TimeoutException e) {
         LOG.error("Connecting to rabbitmq failed, retry in {} seconds. Cause: {}", retryTime, e.getMessage());
         delayRetry(retryTime);
       }
     }
-    connection.addShutdownListener((cause) -> {
+    localConnection.addShutdownListener((cause) -> {
       if (cause.isInitiatedByApplication()) {
         LOG.info("Connection was shut down (by application)");
       } else {
         LOG.warn("Connection has been shut down, trying to reconnect", cause);
       }
     });
-    return connection;
+    return localConnection;
   }
 
   private void delayRetry(final int retryTime) {

--- a/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/WorkerResultSender.java
+++ b/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/WorkerResultSender.java
@@ -69,7 +69,7 @@ public class WorkerResultSender implements WorkerIntermediateResultSender {
     final BasicProperties basicProperties = new BasicProperties.Builder()
         .correlationId(properties.getCorrelationId())
         .messageId(properties.getMessageId())
-        .headers(new HashMap<String, Object>())
+        .headers(new HashMap<>())
         .build();
     // reply to the requested queue, converting the object to bytes first.
     channel.basicPublish(EXCHANGE, queue, basicProperties, data);

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducer.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducer.java
@@ -115,16 +115,18 @@ class RabbitMQWorkerProducer implements WorkerProducer {
   private void tryStartReplyConsumer() {
     boolean warn = true;
     while (!isShutdown) {
-      try {
-        final Connection connection = factory.getConnection();
+      final Connection connection = factory.getConnection();
 
+      try {
         connection.addShutdownListener(this::restartConnection);
         startReplyConsumer(connection);
         LOG.info("Successfully (re)started reply consumer for queue {}", workerQueueName);
         break;
       } catch (final ShutdownSignalException | IOException e1) {
+        connection.removeShutdownListener(this::restartConnection);
         if (warn) {
-          LOG.warn("(Re)starting reply consumer for queue {} failed, retrying in a while", workerQueueName, e1);
+          LOG.warn("(Re)starting reply consumer for queue {} failed, retrying in a while", workerQueueName);
+          LOG.trace("(Re)starting failed with exception:", e1);
           warn = false;
         }
         delayRetry(DEFAULT_RETRY_SECONDS);
@@ -139,7 +141,7 @@ class RabbitMQWorkerProducer implements WorkerProducer {
     tryStartReplyConsumer();
   }
 
-  private void delayRetry(final int retryTime) {
+  private static void delayRetry(final int retryTime) {
     try {
       Thread.sleep(TimeUnit.SECONDS.toMillis(retryTime));
     } catch (final InterruptedException ex) {


### PR DESCRIPTION
On production system when Taskmanager/RabbitMQ is restarted it can happen 2 taskmanagers are run temporary. Because some queues have unique access requirements the newly started taskmanager could complain it can't access the queues. The taskmanager should recover from this, but in the mean time will log numerous errors. This is an attempt to reduce that logging. It was not possible to reproduce the exact logging from production, but this should at least reduce some logging.

Also includes some code cleanup.