### PR TITLE
AER-2293 Set automatic recovery to false for RabbitMQ library

### DIFF
--- a/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/BrokerConnectionFactory.java
+++ b/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/BrokerConnectionFactory.java
@@ -63,6 +63,10 @@ public class BrokerConnectionFactory {
     factory.setUsername(connectionConfiguration.getBrokerUsername());
     factory.setPassword(connectionConfiguration.getBrokerPassword());
     factory.setVirtualHost(connectionConfiguration.getBrokerVirtualHost());
+    // Set automatic recovery to false - as of 4.0.0 this is true by default which will not mix well with our own connection retries.
+    // In a future version we might want to use this rather than have our own implementation.
+    // See https://www.rabbitmq.com/api-guide.html#recovery for more information.
+    factory.setAutomaticRecoveryEnabled(false);
   }
 
   public ConnectionConfiguration getConnectionConfiguration() {


### PR DESCRIPTION
As of 4.0.0 of the library this is true by default which will not mix well with our own connection retries. In a future version we might want to use this rather than have our own implementation. See https://www.rabbitmq.com/api-guide.html#recovery for more information.