### PR TITLE
Taskmanager stability issues

### DIFF
--- a/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/mq/RabbitMQWorkerMonitor.java
+++ b/source/taskmanager-client/src/main/java/nl/aerius/taskmanager/client/mq/RabbitMQWorkerMonitor.java
@@ -149,6 +149,7 @@ public class RabbitMQWorkerMonitor {
         @Override
         public void handleShutdownSignal(final String consumerTag, final ShutdownSignalException sig) {
           if (sig.isInitiatedByApplication()) {
+            isShutdown = true;
             LOG.info("Worker event monitor {} was shut down by the application.", consumerTag);
           } else {
             LOG.debug("Worker event monitor {} was shut down.", consumerTag);

--- a/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/mq/RabbitMQWorkerMonitorTest.java
+++ b/source/taskmanager-client/src/test/java/nl/aerius/taskmanager/client/mq/RabbitMQWorkerMonitorTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -74,6 +75,7 @@ class RabbitMQWorkerMonitorTest {
     final Connection mockConnection = Mockito.mock(Connection.class);
     mockChannel = Mockito.mock(Channel.class);
     doReturn(mockChannel).when(mockConnection).createChannel();
+    when(mockChannel.isOpen()).thenReturn(true);
     final Queue.DeclareOk mockDeclareOk = Mockito.mock(Queue.DeclareOk.class);
     doReturn(mockDeclareOk).when(mockChannel).queueDeclare();
     monitor = new RabbitMQWorkerMonitor(new BrokerConnectionFactory(executor) {

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
@@ -96,7 +96,9 @@ class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaDa
           LOG.warn("(Re)starting consumer for {} failed, retrying in a while", taskQueueName, e1);
           warned = true;
         }
-        delayRetry();
+        if (!isShutdown) {
+          delayRetry();
+        }
       }
     }
   }
@@ -168,7 +170,6 @@ class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaDa
       return;
     }
     if (!tryStartingConsuming.get() && tryConnecting.compareAndSet(false, true) && messageReceivedHandler != null) {
-      delayRetry();
       messageReceivedHandler.handleShutdownSignal();
     }
   }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducer.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducer.java
@@ -131,7 +131,9 @@ class RabbitMQWorkerProducer implements WorkerProducer {
           LOG.trace("(Re)starting failed with exception:", e1);
           warn = false;
         }
-        delayRetry(DEFAULT_RETRY_SECONDS);
+        if (!isShutdown) {
+          delayRetry(DEFAULT_RETRY_SECONDS);
+        }
       }
     }
   }


### PR DESCRIPTION
During some local testing, I ended up with a system that wasn't calculating anymore. A few things were changed:
- Opening a connection was moved outside of a try-with-resources block. As the exceptions can also occur within this opening method, moved it back in.
- Avoid delay in handleShutdownSignal method in handlers: this caused the old (unusable) AMQP Connection thread to stay up for way too long, and as each handler had to wait for the other, the state of the system would also be updated late (not a 100% sure this was an issue, it was just noticable and don't really see a point in the delay at this point)
- Sturdier WorkerMonitor: locally I ended up in a system where worker would pick up a calculation (as it was already on the worker queue) but it wouldn't send out any tasks to the workers. Turned out that when rebooting RabbitMQ occasionally the workermonitor wouldn't kick in again (no queues anymore on the event exchange). Not a 100% sure this is what happened, but think that the `start()` method that was called in the `handleShutdownSignal` method would also throw an exception, and it would not be attempted to start again.