### PR TITLE
[RELEASE-FIX] Use JDK 17 to build

### DIFF
--- a/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
+++ b/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ROOT_POM_DIRECTORY: repo/source
+          JDK_VERSION: 17
 
       - uses: aerius/github-actions/extras/docker-build-action@v1.0.2
         with:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -22,6 +22,7 @@ jobs:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           ROOT_POM_DIRECTORY: repo/source
+          JDK_VERSION: 17
 
       - uses: aerius/github-actions/extras/docker-build-or-publish-based-on-maven-project-version-action@v1.0.2
         with:
@@ -31,3 +32,4 @@ jobs:
           DOCKER_IMAGE_NAME: ${{ github.event.repository.name }}
           DOCKER_WORK_DIRECTORY: repo/source
           ROOT_POM_DIRECTORY: repo/source
+          JDK_VERSION: 17

--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -23,6 +23,7 @@ jobs:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           ROOT_POM_DIRECTORY: repo/source
+          JDK_VERSION: 17
 
       - uses: aerius/github-actions/extras/docker-publish-action@v1.0.2
         with:
@@ -32,3 +33,4 @@ jobs:
           DOCKER_IMAGE_NAME: ${{ github.event.repository.name }}
           ROOT_POM_DIRECTORY: repo/source
           DOCKER_WORK_DIRECTORY: repo/source
+          JDK_VERSION: 17


### PR DESCRIPTION
Sonar does not like using JDK 11 anymore, and since sonar is part of the release step...