### PR TITLE
Fix for declaring worker queue

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/AdaptorFactory.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/AdaptorFactory.java
@@ -33,11 +33,10 @@ public interface AdaptorFactory {
 
   /**
    * Creates a new worker producer for the given worker type.
-   * @param workerQueueName name of queue of the worker
-   * @param durable true if the queue created should be persistent during server restart
+   * @param queueConfig Configuration parameters for the queue
    * @return new worker producer object
    */
-  WorkerProducer createWorkerProducer(String workerQueueName, boolean durable);
+  WorkerProducer createWorkerProducer(QueueConfig queueConfig);
 
   /**
    * Creates a new TaksMessageHandler for the given worker type and queue.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQAdaptorFactory.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQAdaptorFactory.java
@@ -56,7 +56,7 @@ public class RabbitMQAdaptorFactory implements AdaptorFactory {
   }
 
   @Override
-  public WorkerProducer createWorkerProducer(final String workerQueueName, final boolean durable) {
-    return new RabbitMQWorkerProducer(factory, workerQueueName, durable);
+  public WorkerProducer createWorkerProducer(final QueueConfig queueConfig) {
+    return new RabbitMQWorkerProducer(factory, queueConfig);
   }
 }

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockAdaptorFactory.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockAdaptorFactory.java
@@ -40,7 +40,7 @@ public class MockAdaptorFactory implements AdaptorFactory {
   }
 
   @Override
-  public WorkerProducer createWorkerProducer(final String workerQueueName, final boolean durable) {
+  public WorkerProducer createWorkerProducer(final QueueConfig queueConfig) {
     return mockWorkerProducer;
   }
 

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducerTest.java
@@ -32,6 +32,7 @@ import com.rabbitmq.client.Envelope;
 
 import nl.aerius.taskmanager.adaptor.WorkerProducer;
 import nl.aerius.taskmanager.adaptor.WorkerSizeObserver;
+import nl.aerius.taskmanager.domain.QueueConfig;
 
 /**
  * Test class for {@link RabbitMQWorkerProducer}.
@@ -47,7 +48,7 @@ class RabbitMQWorkerProducerTest extends AbstractRabbitMQTest {
   void testForwardMessage() throws IOException, InterruptedException {
     final byte[] sendBody = "4321".getBytes();
 
-    final WorkerProducer wp = adapterFactory.createWorkerProducer(WORKER_QUEUE_NAME, false);
+    final WorkerProducer wp = adapterFactory.createWorkerProducer(new QueueConfig(WORKER_QUEUE_NAME, false, null));
     wp.start();
     final BasicProperties bp = new BasicProperties();
     wp.forwardMessage(new RabbitMQMessage(WORKER_QUEUE_NAME, null, 4321, bp, sendBody) {


### PR DESCRIPTION
Changes made to declaring worker queue incorrectly created worker queue always are quorum, and also missed a call to one declare. With this change it's fully backward compatible.