### PR TITLE
Adjusted use of executorservice in taskmanager

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/Main.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/Main.java
@@ -70,18 +70,10 @@ public final class Main {
       }
     });
     Thread.currentThread().setName("Main");
-    final ExecutorService executorService = Executors.newCachedThreadPool();
-    final ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(THREAD_POOL_SIZE);
 
-    try {
+    try (final ExecutorService executorService = Executors.newCachedThreadPool();
+        final ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(THREAD_POOL_SIZE)) {
       startupFromConfiguration(executorService, scheduledExecutorService, cmdOptions.getConfigFile());
-    } finally {
-      if (!executorService.isTerminated()) {
-        executorService.shutdown();
-      }
-      if (!scheduledExecutorService.isTerminated()) {
-        scheduledExecutorService.shutdown();
-      }
     }
   }
 


### PR DESCRIPTION
Since java 19, ExecutorService implements AutoCloseable. As such, Sonar complains about the existing code that it didn't close properly. As the default close method also does the terminated and shutdown check (and some more bits), went with just using the try-with-resources approach.