### PR TITLE
Add mockito as test dependency

### DIFF
--- a/source/taskmanager-client/pom.xml
+++ b/source/taskmanager-client/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Root pom now specifies mockito as a javaagent. In most cases that's fine, but some modules do not yet have mockito as a test dependency, and would fail because the necessary property with location of the javaagent jar would not be present. As it's a common test dependency, think it's fine to add it even if mockito isn't (yet) used in a module.