### PR TITLE
Improve shutdown handling

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQChannelQueueEventsWatcher.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQChannelQueueEventsWatcher.java
@@ -79,7 +79,10 @@ class RabbitMQChannelQueueEventsWatcher {
     }
   }
 
-  private void handleShutdownSignal(final ShutdownSignalException sig) {
+  private void handleShutdownSignal(final ShutdownSignalException sse) {
+    if (sse != null && sse.isInitiatedByApplication()) {
+      return;
+    }
     LOG.debug("Channel RabbitMQChannelQueueEventsWatcher was shut down.");
     // restart
     try {

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
@@ -98,9 +98,9 @@ class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaDa
           LOG.warn("(Re)starting consumer for {} failed, retrying in a while", taskQueueName, e1);
           warned = true;
         }
-        if (!isShutdown) {
-          delayRetry();
-        }
+      }
+      if (!isShutdown) {
+        delayRetry();
       }
     }
   }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
@@ -17,12 +17,14 @@
 package nl.aerius.taskmanager.mq;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.ShutdownSignalException;
 
 import nl.aerius.taskmanager.adaptor.TaskMessageHandler;
@@ -84,11 +86,12 @@ class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaDa
     tryStartingConsuming.set(true);
     while (!isShutdown) {
       try {
-        stopAndStartConsumer();
-        LOG.info("Successfully (re)started consumer for {}", taskQueueName);
-        if (consumer.getChannel().isOpen()) {
-          tryStartingConsuming.set(false);
-          break;
+        if (stopAndStartConsumer()) {
+          LOG.info("Successfully (re)started consumer for {}", taskQueueName);
+          if (consumer.getChannel().isOpen()) {
+            tryStartingConsuming.set(false);
+            return;
+          }
         }
       } catch (final ShutdownSignalException | IOException e1) {
         if (!warned) {
@@ -147,24 +150,28 @@ class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaDa
     }
   }
 
-  private void stopAndStartConsumer() throws IOException {
+  private boolean stopAndStartConsumer() throws IOException {
     synchronized (this) {
       if (consumer != null) {
         consumer.stopConsuming();
       }
-      consumer = new RabbitMQMessageConsumer(
-          factory.getConnection().createChannel(),
-          queueConfig,
-          this);
-      consumer.getChannel().addShutdownListener(this::handleShutdownSignal);
-      consumer.startConsuming();
-      tryConnecting.set(false);
-      warned = false;
+      final Optional<Channel> channel = factory.getConnection().openChannel();
+
+      if (channel.isPresent()) {
+        consumer = new RabbitMQMessageConsumer(channel.get(), queueConfig, this);
+        consumer.getChannel().addShutdownListener(this::handleShutdownSignal);
+        consumer.startConsuming();
+        tryConnecting.set(false);
+        warned = false;
+        return true;
+      } else {
+        return false;
+      }
     }
   }
 
-  private void handleShutdownSignal(final ShutdownSignalException ssg) {
-    if (ssg != null && ssg.isInitiatedByApplication()) {
+  private void handleShutdownSignal(final ShutdownSignalException sse) {
+    if (sse != null && sse.isInitiatedByApplication()) {
       return;
     }
     if (!tryStartingConsuming.get() && tryConnecting.compareAndSet(false, true) && messageReceivedHandler != null) {

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/AbstractRabbitMQTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/AbstractRabbitMQTest.java
@@ -16,8 +16,9 @@
  */
 package nl.aerius.taskmanager.mq;
 
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -63,7 +64,8 @@ class AbstractRabbitMQTest {
         .brokerHost("localhost").brokerUsername("guest").brokerPassword("guest").build();
     mockChannel = MockedChannelFactory.create();
 
-    doReturn(mockChannel).when(mockConnection).createChannel();
+    lenient().doReturn(mockChannel).when(mockConnection).createChannel();
+    lenient().doReturn(Optional.of(mockChannel)).when(mockConnection).openChannel();
     factory = new BrokerConnectionFactory(executor, configuration) {
       @Override
       protected Connection createNewConnection() {


### PR DESCRIPTION
- No handler on reply queue. If connection down it will already be restarted by the worker connection itself.
- Added check if application did shutdown on queue event watcher, because than no restart needed.