### PR TITLE
Move scheduler implementation to own package

### DIFF
--- a/source/pom.xml
+++ b/source/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>taskmanager-parent</artifactId>
-  <version>1.13.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Taskmanager</name>
   <url>https://www.aerius.nl</url>

--- a/source/taskmanager-client/pom.xml
+++ b/source/taskmanager-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>taskmanager-parent</artifactId>
-    <version>1.13.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>taskmanager-client</artifactId>

--- a/source/taskmanager-report/pom.xml
+++ b/source/taskmanager-report/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>taskmanager-parent</artifactId>
-    <version>1.13.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>taskmanager-report</artifactId>

--- a/source/taskmanager-test/pom.xml
+++ b/source/taskmanager-test/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>taskmanager-parent</artifactId>
-    <version>1.13.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>taskmanager-test</artifactId>

--- a/source/taskmanager/pom.xml
+++ b/source/taskmanager/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>taskmanager-parent</artifactId>
-    <version>1.13.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>taskmanager</artifactId>

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/Main.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/Main.java
@@ -26,7 +26,6 @@ import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import nl.aerius.taskmanager.PriorityTaskScheduler.PriorityTaskSchedulerFactory;
 import nl.aerius.taskmanager.adaptor.AdaptorFactory;
 import nl.aerius.taskmanager.adaptor.WorkerSizeProviderProxy;
 import nl.aerius.taskmanager.client.BrokerConnectionFactory;
@@ -34,6 +33,7 @@ import nl.aerius.taskmanager.domain.PriorityTaskQueue;
 import nl.aerius.taskmanager.domain.PriorityTaskSchedule;
 import nl.aerius.taskmanager.domain.TaskManagerConfiguration;
 import nl.aerius.taskmanager.mq.RabbitMQAdaptorFactory;
+import nl.aerius.taskmanager.scheduler.priorityqueue.PriorityTaskSchedulerFactory;
 
 /**
  * The main class, used to start the task manager.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskConsumerImpl.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskConsumerImpl.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.taskmanager;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.context.Context;
+
+import nl.aerius.taskmanager.adaptor.AdaptorFactory;
+import nl.aerius.taskmanager.adaptor.TaskMessageHandler;
+import nl.aerius.taskmanager.domain.ForwardTaskHandler;
+import nl.aerius.taskmanager.domain.Message;
+import nl.aerius.taskmanager.domain.MessageMetaData;
+import nl.aerius.taskmanager.domain.QueueConfig;
+import nl.aerius.taskmanager.domain.Task;
+import nl.aerius.taskmanager.domain.TaskConsumer;
+
+/**
+ * Task manager part of retrieving tasks from the client queues and send them to the dispatcher, which in case will send them to the scheduler.
+ * It also listens to if the message was successfully send to the worker.
+ */
+public class TaskConsumerImpl implements TaskConsumer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TaskConsumerImpl.class);
+
+  private final ExecutorService executorService;
+  private final String taskQueueName;
+  private final ForwardTaskHandler forwardTaskHandler;
+  private final TaskMessageHandler<MessageMetaData, Message<MessageMetaData>> taskMessageHandler;
+
+  private boolean running = true;
+
+  private Future<?> messageHandlerFuture;
+
+  @SuppressWarnings("unchecked")
+  public TaskConsumerImpl(final ExecutorService executorService, final QueueConfig queueConfig, final ForwardTaskHandler forwardTaskHandler,
+      final AdaptorFactory factory) throws IOException {
+    this.executorService = executorService;
+    this.taskQueueName = queueConfig.queueName();
+    this.forwardTaskHandler = forwardTaskHandler;
+    this.taskMessageHandler = factory.createTaskMessageHandler(queueConfig);
+    taskMessageHandler.addMessageReceivedHandler(this);
+  }
+
+  @Override
+  public String getQueueName() {
+    return taskQueueName;
+  }
+
+  /**
+   * @return true if is running
+   */
+  @Override
+  public boolean isRunning() {
+    return running;
+  }
+
+  @Override
+  public void onMessageReceived(final Message<?> message) {
+    if (running) {
+      final Task task = new Task(this);
+
+      task.setData(message);
+      task.setContext(Context.current());
+      LOG.trace("Task received from {} for worker send to scheduler ({}).", taskQueueName, task.getId());
+      forwardTaskHandler.forwardTask(task);
+    }
+  }
+
+  @Override
+  public void handleShutdownSignal() {
+    forwardTaskHandler.killTasks();
+    start();
+  }
+
+  @Override
+  public void messageDelivered(final MessageMetaData messageMetaData) throws IOException {
+    taskMessageHandler.messageDeliveredToWorker(messageMetaData);
+  }
+
+  /**
+   * Inform the consumer the message delivery failed.
+   *
+   * @param messageMetaData Meta data of the message that failed
+   * @throws IOException
+   */
+  @Override
+  public void messageDeliveryFailed(final MessageMetaData messageMetaData) throws IOException {
+    taskMessageHandler.messageDeliveryToWorkerFailed(messageMetaData);
+  }
+
+  /**
+   * Inform the consumer the message delivery failed.
+   * @param message message that failed
+   * @param exception the exception with which the message failed
+   * @throws IOException
+   */
+  @Override
+  public void messageDeliveryAborted(final Message<MessageMetaData> message, final RuntimeException exception) throws IOException {
+    taskMessageHandler.messageDeliveryAborted(message, exception);
+  }
+
+  @Override
+  public synchronized void start() {
+    if (messageHandlerFuture != null && !messageHandlerFuture.isDone()) {
+      try {
+        messageHandlerFuture.get();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (final ExecutionException e) {
+        LOG.info("TaskConsumer shutdown {} got exception.", taskQueueName, e);
+      }
+    }
+    messageHandlerFuture = executorService.submit(() -> {
+      try {
+        taskMessageHandler.start();
+      } catch (final IOException e) {
+        LOG.error("TaskConsumer for {} got IO problems.", taskQueueName, e);
+      }
+    });
+  }
+
+  /**
+   * Shutdown the task consumer.
+   */
+  @Override
+  public void shutdown() {
+    running = false;
+    try {
+      taskMessageHandler.shutDown();
+    } catch (final IOException e) {
+      // eat error on shutdown
+      LOG.trace("Exception while shutting down", e);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "TaskConsumer [taskQueueName=" + taskQueueName + ", running=" + running + "]";
+  }
+}

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskDispatcher.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskDispatcher.java
@@ -26,8 +26,12 @@ import org.slf4j.LoggerFactory;
 
 import com.rabbitmq.client.ShutdownSignalException;
 
+import nl.aerius.taskmanager.domain.ForwardTaskHandler;
+import nl.aerius.taskmanager.domain.Task;
+import nl.aerius.taskmanager.domain.TaskConsumer;
 import nl.aerius.taskmanager.exception.NoFreeWorkersException;
 import nl.aerius.taskmanager.exception.TaskAlreadySentException;
+import nl.aerius.taskmanager.scheduler.TaskScheduler;
 
 /**
  * Control center for processing tasks.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskManager.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskManager.java
@@ -161,7 +161,7 @@ class TaskManager<T extends TaskQueue, S extends TaskSchedule<T>> {
     public void addTaskConsumerIfAbsent(final QueueConfig queueConfig) {
       taskConsumers.computeIfAbsent(queueConfig.queueName(), tqn -> {
         try {
-          final TaskConsumer taskConsumer = new TaskConsumer(executorService, queueConfig, dispatcher, factory);
+          final TaskConsumer taskConsumer = new TaskConsumerImpl(executorService, queueConfig, dispatcher, factory);
           taskConsumer.start();
           LOG.info("Started task queue {} (durable:{}, queueType:{})", queueConfig.queueName(), queueConfig.durable(), queueConfig.queueType());
           return taskConsumer;

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskManager.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskManager.java
@@ -31,14 +31,16 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import nl.aerius.taskmanager.TaskScheduler.TaskSchedulerFactory;
 import nl.aerius.taskmanager.adaptor.AdaptorFactory;
 import nl.aerius.taskmanager.adaptor.WorkerProducer;
 import nl.aerius.taskmanager.adaptor.WorkerSizeProviderProxy;
 import nl.aerius.taskmanager.domain.QueueConfig;
 import nl.aerius.taskmanager.domain.RabbitMQQueueType;
+import nl.aerius.taskmanager.domain.TaskConsumer;
 import nl.aerius.taskmanager.domain.TaskQueue;
 import nl.aerius.taskmanager.domain.TaskSchedule;
+import nl.aerius.taskmanager.scheduler.TaskScheduler;
+import nl.aerius.taskmanager.scheduler.TaskScheduler.TaskSchedulerFactory;
 
 /**
  * Main task manager class, manages all schedulers.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskSchedulerWatcher.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskSchedulerWatcher.java
@@ -34,10 +34,10 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import nl.aerius.taskmanager.TaskScheduler.TaskSchedulerFactory;
 import nl.aerius.taskmanager.client.WorkerQueueType;
 import nl.aerius.taskmanager.domain.TaskQueue;
 import nl.aerius.taskmanager.domain.TaskSchedule;
+import nl.aerius.taskmanager.scheduler.TaskScheduler.TaskSchedulerFactory;
 
 /**
  * Class that watches the file system for queue configuration changes and passed any changes to the {@link TaskManager} class.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/WorkerPool.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/WorkerPool.java
@@ -29,6 +29,7 @@ import nl.aerius.taskmanager.adaptor.WorkerProducer;
 import nl.aerius.taskmanager.adaptor.WorkerProducer.WorkerFinishedHandler;
 import nl.aerius.taskmanager.adaptor.WorkerProducer.WorkerMetrics;
 import nl.aerius.taskmanager.domain.Task;
+import nl.aerius.taskmanager.domain.WorkerUpdateHandler;
 import nl.aerius.taskmanager.adaptor.WorkerSizeObserver;
 import nl.aerius.taskmanager.exception.NoFreeWorkersException;
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/WorkerPool.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/WorkerPool.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import nl.aerius.taskmanager.adaptor.WorkerProducer;
 import nl.aerius.taskmanager.adaptor.WorkerProducer.WorkerFinishedHandler;
 import nl.aerius.taskmanager.adaptor.WorkerProducer.WorkerMetrics;
+import nl.aerius.taskmanager.domain.Task;
 import nl.aerius.taskmanager.adaptor.WorkerSizeObserver;
 import nl.aerius.taskmanager.exception.NoFreeWorkersException;
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/WorkerUpdateHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/WorkerUpdateHandler.java
@@ -19,7 +19,7 @@ package nl.aerius.taskmanager;
 /**
  * Handler to be informed when changed related to handling or tasks by workers and worker pool changes.
  */
-interface WorkerUpdateHandler {
+public interface WorkerUpdateHandler {
 
   /**
    * Task has be processed by the worker pool and finished with results.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/TaskMessageHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/TaskMessageHandler.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import nl.aerius.taskmanager.domain.Message;
 import nl.aerius.taskmanager.domain.MessageMetaData;
+import nl.aerius.taskmanager.domain.MessageReceivedHandler;
 
 /**
  * Interface for service receiving messages from a queue and pass them to the {@link MessageReceivedHandler}.
@@ -67,23 +68,5 @@ public interface TaskMessageHandler<E extends MessageMetaData, M extends Message
    * @throws IOException connection errors
    */
   void messageDeliveryAborted(M message, RuntimeException exception) throws IOException;
-
-  /**
-   * Class implementing this handler will get the messages received by the {@link TaskMessageHandler}.
-   */
-  interface MessageReceivedHandler {
-
-    /**
-     * Message received from queue.
-     *
-     * @param message the message
-     */
-    void onMessageReceived(Message<?> message);
-
-    /**
-     * Called when the Consumer was shutdown.
-     */
-    void handleShutdownSignal();
-  }
 
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/ForwardTaskHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/ForwardTaskHandler.java
@@ -14,12 +14,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
+package nl.aerius.taskmanager.domain;
 
 /**
  * Interface for class implementing forwarding to the scheduler.
  */
-interface ForwardTaskHandler {
+public interface ForwardTaskHandler {
 
   /**
    * Forwards the task to the scheduler, which adds the task to the pool of tasks to be handled. This method

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/MessageReceivedHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/MessageReceivedHandler.java
@@ -14,22 +14,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
-
-import nl.aerius.taskmanager.domain.WorkerUpdateHandler;
+package nl.aerius.taskmanager.domain;
 
 /**
- * Mock implementation of {@link WorkerUpdateHandler}.
+ * Class implementing this handler will get the messages received by the TaskMessageHandler.
  */
-public class MockTaskFinishedHandler implements WorkerUpdateHandler {
+public interface MessageReceivedHandler {
 
-  @Override
-  public void onTaskFinished(final String queueName) {
-    //no-op
-  }
+  /**
+   * Message received from queue.
+   *
+   * @param message the message
+   */
+  void onMessageReceived(Message<?> message);
 
-  @Override
-  public void onWorkerPoolSizeChange(final int numberOfWorkers) {
-    //no-op
-  }
+  /**
+   * Called when the Consumer was shutdown.
+   */
+  void handleShutdownSignal();
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/RabbitMQQueueType.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/RabbitMQQueueType.java
@@ -19,7 +19,9 @@ package nl.aerius.taskmanager.domain;
 import java.util.Locale;
 
 public enum RabbitMQQueueType {
-  CLASSIC, QUORUM, STREAM;
+  CLASSIC,
+  QUORUM,
+  STREAM;
 
   public String type() {
     return name().toLowerCase(Locale.ROOT);

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/Task.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/Task.java
@@ -14,18 +14,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
+package nl.aerius.taskmanager.domain;
 
 import io.opentelemetry.context.Context;
-
-import nl.aerius.taskmanager.domain.Message;
-import nl.aerius.taskmanager.domain.MessageMetaData;
 
 /**
  * Task manager internal data object to track messages. A Message is a generic interface which is used with a interface specific (e.g. RabbitMQ)
  * instances. This data object keeps track of the taskconsumer that send the message.
  */
-class Task {
+public class Task {
   private Message<?> data;
   private final TaskConsumer taskConsumer;
   private boolean alive = true;

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/TaskConsumer.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/TaskConsumer.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
+package nl.aerius.taskmanager.domain;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -24,18 +24,17 @@ import java.util.concurrent.Future;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.opentelemetry.context.Context;
+
 import nl.aerius.taskmanager.adaptor.AdaptorFactory;
 import nl.aerius.taskmanager.adaptor.TaskMessageHandler;
 import nl.aerius.taskmanager.adaptor.TaskMessageHandler.MessageReceivedHandler;
-import nl.aerius.taskmanager.domain.Message;
-import nl.aerius.taskmanager.domain.MessageMetaData;
-import nl.aerius.taskmanager.domain.QueueConfig;
 
 /**
  * Task manager part of retrieving tasks from the client queues and send them to the dispatcher, which in case will send them to the scheduler.
  * It also listens to if the message was successfully send to the worker.
  */
-class TaskConsumer implements MessageReceivedHandler {
+public class TaskConsumer implements MessageReceivedHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(TaskConsumer.class);
 
@@ -73,7 +72,9 @@ class TaskConsumer implements MessageReceivedHandler {
   public void onMessageReceived(final Message<?> message) {
     if (running) {
       final Task task = new Task(this);
+
       task.setData(message);
+      task.setContext(Context.current());
       LOG.trace("Task received from {} for worker send to scheduler ({}).", taskQueueName, task.getId());
       forwardTaskHandler.forwardTask(task);
     }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/WorkerUpdateHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/WorkerUpdateHandler.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
+package nl.aerius.taskmanager.domain;
 
 /**
  * Handler to be informed when changed related to handling or tasks by workers and worker pool changes.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
@@ -30,6 +30,7 @@ import com.rabbitmq.client.ShutdownSignalException;
 import nl.aerius.taskmanager.adaptor.TaskMessageHandler;
 import nl.aerius.taskmanager.client.BrokerConnectionFactory;
 import nl.aerius.taskmanager.client.WorkerResultSender;
+import nl.aerius.taskmanager.domain.MessageReceivedHandler;
 import nl.aerius.taskmanager.domain.QueueConfig;
 import nl.aerius.taskmanager.mq.RabbitMQMessageConsumer.ConsumerCallback;
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/SchedulerFileConfigurationHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/SchedulerFileConfigurationHandler.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
+package nl.aerius.taskmanager.scheduler;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +27,7 @@ import nl.aerius.taskmanager.domain.TaskSchedule;
  * @param <T>
  * @param <S>
  */
-interface SchedulerFileConfigurationHandler<T extends TaskQueue, S extends TaskSchedule<T>> {
+public interface SchedulerFileConfigurationHandler<T extends TaskQueue, S extends TaskSchedule<T>> {
 
   /**
    * Reads a scheduler configuration file and returns the parsed data object

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/TaskScheduler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/TaskScheduler.java
@@ -14,18 +14,19 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
+package nl.aerius.taskmanager.scheduler;
 
+import nl.aerius.taskmanager.WorkerUpdateHandler;
+import nl.aerius.taskmanager.domain.Task;
 import nl.aerius.taskmanager.domain.TaskQueue;
 import nl.aerius.taskmanager.domain.TaskSchedule;
 
 /**
- * Interface for the scheduling algorithm. The implementation should maintain an internal list of all tasks added and
- * return the task to be processed in {@link #getNextTask()} based on whatever priority algorithm the scheduler
- * implements. When a task is finished the scheduler receives {@link #onTaskFinished(Task)} event with the task
- * finished.
+ * Interface for the scheduling algorithm. The implementation should maintain an internal list of all tasks added and return the task to be processed
+ * in {@link #getNextTask()} based on whatever priority algorithm the scheduler implements. When a task is finished the scheduler receives
+ * {@link WorkerUpdateHandler#onTaskFinished(Task)} event with the task finished.
  */
-interface TaskScheduler<T extends TaskQueue> extends WorkerUpdateHandler {
+public interface TaskScheduler<T extends TaskQueue> extends WorkerUpdateHandler {
 
   /**
    * Adds a Task to the scheduler to being processed. The scheduler will return this task in {@link #getNextTask()}
@@ -70,7 +71,8 @@ interface TaskScheduler<T extends TaskQueue> extends WorkerUpdateHandler {
 
     /**
      * Create a new scheduler.
-     * @param configurationFile scheduler configuration
+     *
+     * @param workerQueueName the worker queue the scheduler is creatd for
      * @return new task scheduler
      */
     TaskScheduler<T> createScheduler(String workerQueueName);

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/TaskScheduler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/TaskScheduler.java
@@ -16,15 +16,14 @@
  */
 package nl.aerius.taskmanager.scheduler;
 
-import nl.aerius.taskmanager.WorkerUpdateHandler;
 import nl.aerius.taskmanager.domain.Task;
 import nl.aerius.taskmanager.domain.TaskQueue;
 import nl.aerius.taskmanager.domain.TaskSchedule;
+import nl.aerius.taskmanager.domain.WorkerUpdateHandler;
 
 /**
  * Interface for the scheduling algorithm. The implementation should maintain an internal list of all tasks added and return the task to be processed
- * in {@link #getNextTask()} based on whatever priority algorithm the scheduler implements. When a task is finished the scheduler receives
- * {@link WorkerUpdateHandler#onTaskFinished(Task)} event with the task finished.
+ * in {@link #getNextTask()} based on whatever priority algorithm the scheduler implements.
  */
 public interface TaskScheduler<T extends TaskQueue> extends WorkerUpdateHandler {
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/fifo/FIFOTaskScheduler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/fifo/FIFOTaskScheduler.java
@@ -14,18 +14,21 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
+package nl.aerius.taskmanager.scheduler.fifo;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import nl.aerius.taskmanager.domain.PriorityTaskQueue;
 import nl.aerius.taskmanager.domain.PriorityTaskSchedule;
+import nl.aerius.taskmanager.domain.Task;
+import nl.aerius.taskmanager.scheduler.TaskScheduler;
+import nl.aerius.taskmanager.scheduler.priorityqueue.PriorityTaskSchedulerFileHandler;
 
 /**
  * FIFO implementation of the task scheduler.
  */
-class FIFOTaskScheduler implements TaskScheduler<PriorityTaskQueue> {
+public class FIFOTaskScheduler implements TaskScheduler<PriorityTaskQueue> {
 
   private final BlockingQueue<Task> tasks = new LinkedBlockingQueue<>();
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityQueueMap.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityQueueMap.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.taskmanager.scheduler.priorityqueue;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import nl.aerius.taskmanager.domain.PriorityTaskQueue;
+
+/**
+ * Map to keep track of queue configurations and number of tasks running on workers.
+ */
+class PriorityQueueMap {
+  /**
+   * Map to keep track of queue configuration per queue.
+   */
+  private final Map<String, PriorityTaskQueue> taskQueueConfigurations = new ConcurrentHashMap<>();
+  /**
+   * Map to keep track of the number of tasks running on workers per queue.
+   */
+  private final Map<String, AtomicInteger> tasksOnWorkersPerQueue = new ConcurrentHashMap<>();
+  private final Function<String, String> keyMapper;
+
+  public PriorityQueueMap() {
+    this(Function.identity());
+  }
+
+  public PriorityQueueMap(final Function<String, String> keyMapper) {
+    this.keyMapper = keyMapper;
+  }
+
+  public PriorityTaskQueue get(final String queueName) {
+    return taskQueueConfigurations.get(key(queueName));
+  }
+
+  public boolean containsKey(final String queueName) {
+    return taskQueueConfigurations.containsKey(key(queueName));
+  }
+
+  public PriorityTaskQueue put(final String queueName, final PriorityTaskQueue queue) {
+    final String keyQueueName = key(queueName);
+
+    tasksOnWorkersPerQueue.computeIfAbsent(keyQueueName, k -> new AtomicInteger());
+    return taskQueueConfigurations.put(keyQueueName, queue);
+  }
+
+  public void decrementOnWorker(final String queueName) {
+    tasksOnWorkersPerQueue.get(key(queueName)).decrementAndGet();
+  }
+
+  public void incrementOnWorker(final String queueName) {
+    tasksOnWorkersPerQueue.get(key(queueName)).incrementAndGet();
+  }
+
+  public int onWorker(final String queueName) {
+    return Optional.ofNullable(tasksOnWorkersPerQueue.get(key(queueName))).map(AtomicInteger::intValue).orElse(0);
+  }
+
+  public void remove(final String queueName) {
+    final String keyQueueName = key(queueName);
+
+    taskQueueConfigurations.remove(keyQueueName);
+    tasksOnWorkersPerQueue.remove(keyQueueName);
+  }
+
+  private String key(final String queueName) {
+    return keyMapper.apply(queueName);
+  }
+}

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerFactory.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.taskmanager.scheduler.priorityqueue;
+import nl.aerius.taskmanager.domain.PriorityTaskQueue;
+import nl.aerius.taskmanager.domain.PriorityTaskSchedule;
+import nl.aerius.taskmanager.scheduler.TaskScheduler;
+import nl.aerius.taskmanager.scheduler.TaskScheduler.TaskSchedulerFactory;
+
+/**
+ * Factory to create a scheduler.
+ */
+public class PriorityTaskSchedulerFactory implements TaskSchedulerFactory<PriorityTaskQueue, PriorityTaskSchedule> {
+  private final PriorityTaskSchedulerFileHandler handler = new PriorityTaskSchedulerFileHandler();
+
+  @Override
+  public TaskScheduler<PriorityTaskQueue> createScheduler(final String workerQueueName) {
+    return new PriorityTaskScheduler(new PriorityQueueMap(), workerQueueName);
+  }
+
+  @Override
+  public PriorityTaskSchedulerFileHandler getHandler() {
+    return handler;
+  }
+}

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerFileHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerFileHandler.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
+package nl.aerius.taskmanager.scheduler.priorityqueue;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,11 +28,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import nl.aerius.taskmanager.domain.PriorityTaskQueue;
 import nl.aerius.taskmanager.domain.PriorityTaskSchedule;
+import nl.aerius.taskmanager.scheduler.SchedulerFileConfigurationHandler;
 
 /**
  * Handler to read and write Priority Task Scheduler configuration files.
  */
-class PriorityTaskSchedulerFileHandler implements SchedulerFileConfigurationHandler<PriorityTaskQueue, PriorityTaskSchedule> {
+public class PriorityTaskSchedulerFileHandler implements SchedulerFileConfigurationHandler<PriorityTaskQueue, PriorityTaskSchedule> {
 
   private static final Logger LOG = LoggerFactory.getLogger(PriorityTaskSchedulerFileHandler.class);
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerMetrics.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerMetrics.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
+package nl.aerius.taskmanager.scheduler.priorityqueue;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTask.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTask.java
@@ -19,6 +19,8 @@ package nl.aerius.taskmanager;
 import java.util.UUID;
 
 import nl.aerius.taskmanager.domain.Message;
+import nl.aerius.taskmanager.domain.Task;
+import nl.aerius.taskmanager.domain.TaskConsumer;
 import nl.aerius.taskmanager.mq.RabbitMQMessageMetaData;
 
 /**

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTaskMessageHandler.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTaskMessageHandler.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import nl.aerius.taskmanager.adaptor.TaskMessageHandler;
 import nl.aerius.taskmanager.domain.Message;
 import nl.aerius.taskmanager.domain.MessageMetaData;
+import nl.aerius.taskmanager.domain.MessageReceivedHandler;
 
 /**
  * Mock implementation of {@link TaskMessageHandler}.

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTaskScheduler.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTaskScheduler.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager.scheduler.fifo;
+package nl.aerius.taskmanager;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -26,9 +26,9 @@ import nl.aerius.taskmanager.scheduler.TaskScheduler;
 import nl.aerius.taskmanager.scheduler.priorityqueue.PriorityTaskSchedulerFileHandler;
 
 /**
- * FIFO implementation of the task scheduler.
+ * Mock scheduler, implementing a FIFO algorithm.
  */
-public class FIFOTaskScheduler implements TaskScheduler<PriorityTaskQueue> {
+public class MockTaskScheduler implements TaskScheduler<PriorityTaskQueue> {
 
   private final BlockingQueue<Task> tasks = new LinkedBlockingQueue<>();
 
@@ -67,12 +67,12 @@ public class FIFOTaskScheduler implements TaskScheduler<PriorityTaskQueue> {
     // Not used
   }
 
-  public static class FIFOSchedulerFactory implements TaskSchedulerFactory<PriorityTaskQueue, PriorityTaskSchedule> {
+  public static class MockSchedulerFactory implements TaskSchedulerFactory<PriorityTaskQueue, PriorityTaskSchedule> {
     private final PriorityTaskSchedulerFileHandler handler = new PriorityTaskSchedulerFileHandler();
 
     @Override
-    public FIFOTaskScheduler createScheduler(final String workerQueueName) {
-      return new FIFOTaskScheduler();
+    public MockTaskScheduler createScheduler(final String workerQueueName) {
+      return new MockTaskScheduler();
     }
 
     @Override
@@ -80,4 +80,5 @@ public class FIFOTaskScheduler implements TaskScheduler<PriorityTaskQueue> {
       return handler;
     }
   }
+
 }

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskDispatcherTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskDispatcherTest.java
@@ -38,7 +38,6 @@ import nl.aerius.taskmanager.TaskDispatcher.State;
 import nl.aerius.taskmanager.domain.QueueConfig;
 import nl.aerius.taskmanager.domain.Task;
 import nl.aerius.taskmanager.domain.TaskConsumer;
-import nl.aerius.taskmanager.scheduler.fifo.FIFOTaskScheduler;
 
 /**
  * Test for {@link TaskDispatcher} class.
@@ -57,12 +56,12 @@ class TaskDispatcherTest {
   @BeforeEach
   void setUp() throws IOException {
     executor = Executors.newCachedThreadPool();
-    final FIFOTaskScheduler scheduler = new FIFOTaskScheduler();
+    final MockTaskScheduler scheduler = new MockTaskScheduler();
     workerProducer = new MockWorkerProducer();
     workerPool = new WorkerPool(WORKER_QUEUE_NAME_TEST, workerProducer, scheduler);
     dispatcher = new TaskDispatcher(WORKER_QUEUE_NAME_TEST, scheduler, workerPool);
     factory = new MockAdaptorFactory();
-    taskConsumer = new TaskConsumer(executor, new QueueConfig("testqueue", false, null), dispatcher, factory);
+    taskConsumer = new TaskConsumerImpl(executor, new QueueConfig("testqueue", false, null), dispatcher, factory);
   }
 
   @AfterEach

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskDispatcherTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskDispatcherTest.java
@@ -36,6 +36,9 @@ import org.junit.jupiter.api.Timeout;
 
 import nl.aerius.taskmanager.TaskDispatcher.State;
 import nl.aerius.taskmanager.domain.QueueConfig;
+import nl.aerius.taskmanager.domain.Task;
+import nl.aerius.taskmanager.domain.TaskConsumer;
+import nl.aerius.taskmanager.scheduler.fifo.FIFOTaskScheduler;
 
 /**
  * Test for {@link TaskDispatcher} class.

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskManagerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskManagerTest.java
@@ -29,11 +29,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import nl.aerius.taskmanager.TaskScheduler.TaskSchedulerFactory;
 import nl.aerius.taskmanager.adaptor.AdaptorFactory;
 import nl.aerius.taskmanager.domain.PriorityTaskQueue;
 import nl.aerius.taskmanager.domain.PriorityTaskSchedule;
 import nl.aerius.taskmanager.domain.RabbitMQQueueType;
+import nl.aerius.taskmanager.scheduler.TaskScheduler.TaskSchedulerFactory;
+import nl.aerius.taskmanager.scheduler.fifo.FIFOTaskScheduler;
+import nl.aerius.taskmanager.scheduler.priorityqueue.PriorityTaskSchedulerFileHandler;
 
 /**
  * Test class for {@link TaskManager}.

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskManagerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/TaskManagerTest.java
@@ -29,12 +29,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import nl.aerius.taskmanager.MockTaskScheduler.MockSchedulerFactory;
 import nl.aerius.taskmanager.adaptor.AdaptorFactory;
 import nl.aerius.taskmanager.domain.PriorityTaskQueue;
 import nl.aerius.taskmanager.domain.PriorityTaskSchedule;
 import nl.aerius.taskmanager.domain.RabbitMQQueueType;
-import nl.aerius.taskmanager.scheduler.TaskScheduler.TaskSchedulerFactory;
-import nl.aerius.taskmanager.scheduler.fifo.FIFOTaskScheduler;
 import nl.aerius.taskmanager.scheduler.priorityqueue.PriorityTaskSchedulerFileHandler;
 
 /**
@@ -51,7 +50,7 @@ class TaskManagerTest {
   void setUp() throws IOException {
     executor = Executors.newCachedThreadPool();
     final AdaptorFactory factory = new MockAdaptorFactory();
-    final TaskSchedulerFactory<PriorityTaskQueue, PriorityTaskSchedule> schedulerFactory = new FIFOTaskScheduler.FIFOSchedulerFactory();
+    final MockSchedulerFactory schedulerFactory = new MockTaskScheduler.MockSchedulerFactory();
     taskManager = new TaskManager<>(executor, factory, schedulerFactory, factory.createWorkerSizeProvider());
     schedule = handler.read(new File(getClass().getClassLoader().getResource("queue/priority-task-scheduler.ops.json").getFile()));
   }

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/WorkerPoolTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/WorkerPoolTest.java
@@ -29,8 +29,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import nl.aerius.taskmanager.domain.ForwardTaskHandler;
 import nl.aerius.taskmanager.domain.MessageMetaData;
 import nl.aerius.taskmanager.domain.QueueConfig;
+import nl.aerius.taskmanager.domain.Task;
+import nl.aerius.taskmanager.domain.TaskConsumer;
 import nl.aerius.taskmanager.exception.NoFreeWorkersException;
 import nl.aerius.taskmanager.exception.TaskAlreadySentException;
 import nl.aerius.taskmanager.mq.RabbitMQMessageMetaData;

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/WorkerPoolTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/WorkerPoolTest.java
@@ -34,6 +34,7 @@ import nl.aerius.taskmanager.domain.MessageMetaData;
 import nl.aerius.taskmanager.domain.QueueConfig;
 import nl.aerius.taskmanager.domain.Task;
 import nl.aerius.taskmanager.domain.TaskConsumer;
+import nl.aerius.taskmanager.domain.WorkerUpdateHandler;
 import nl.aerius.taskmanager.exception.NoFreeWorkersException;
 import nl.aerius.taskmanager.exception.TaskAlreadySentException;
 import nl.aerius.taskmanager.mq.RabbitMQMessageMetaData;
@@ -61,7 +62,7 @@ class WorkerPoolTest {
       }
     };
     workerPool = new WorkerPool(WORKER_QUEUE_NAME_TEST, new MockWorkerProducer(), workerUpdateHandler);
-    taskConsumer = new TaskConsumer(mock(ExecutorService.class), new QueueConfig("testqueue", false, null), mock(ForwardTaskHandler.class),
+    taskConsumer = new TaskConsumerImpl(mock(ExecutorService.class), new QueueConfig("testqueue", false, null), mock(ForwardTaskHandler.class),
         new MockAdaptorFactory()) {
       @Override
       public void messageDelivered(final MessageMetaData message) {

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandlerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandlerTest.java
@@ -45,8 +45,8 @@ import com.rabbitmq.client.ShutdownListener;
 import com.rabbitmq.client.ShutdownSignalException;
 
 import nl.aerius.taskmanager.adaptor.TaskMessageHandler;
-import nl.aerius.taskmanager.adaptor.TaskMessageHandler.MessageReceivedHandler;
 import nl.aerius.taskmanager.domain.Message;
+import nl.aerius.taskmanager.domain.MessageReceivedHandler;
 import nl.aerius.taskmanager.domain.QueueConfig;
 
 /**

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerTest.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
+package nl.aerius.taskmanager.scheduler.priorityqueue;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,12 +39,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import nl.aerius.taskmanager.PriorityTaskScheduler.PriorityTaskSchedulerFactory;
+import nl.aerius.taskmanager.MockAdaptorFactory;
+import nl.aerius.taskmanager.domain.ForwardTaskHandler;
 import nl.aerius.taskmanager.domain.Message;
 import nl.aerius.taskmanager.domain.MessageMetaData;
 import nl.aerius.taskmanager.domain.PriorityTaskQueue;
 import nl.aerius.taskmanager.domain.PriorityTaskSchedule;
 import nl.aerius.taskmanager.domain.QueueConfig;
+import nl.aerius.taskmanager.domain.Task;
+import nl.aerius.taskmanager.domain.TaskConsumer;
 
 /**
  * Test class for {@link PriorityTaskScheduler}.

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import nl.aerius.taskmanager.MockAdaptorFactory;
+import nl.aerius.taskmanager.TaskConsumerImpl;
 import nl.aerius.taskmanager.domain.ForwardTaskHandler;
 import nl.aerius.taskmanager.domain.Message;
 import nl.aerius.taskmanager.domain.MessageMetaData;
@@ -277,7 +278,7 @@ class PriorityTaskSchedulerTest {
   }
 
   private TaskConsumer createMockTaskConsumer(final String taskQueueName) throws IOException {
-    return new TaskConsumer(mock(ExecutorService.class), new QueueConfig(taskQueueName, false, null), mock(ForwardTaskHandler.class),
+    return new TaskConsumerImpl(mock(ExecutorService.class), new QueueConfig(taskQueueName, false, null), mock(ForwardTaskHandler.class),
         new MockAdaptorFactory()) {
       @Override
       public void messageDelivered(final MessageMetaData messageMetaData) {


### PR DESCRIPTION
This to keep better oversight of the code as more features will be added to the scheduler. Also moved some code out of PriorityScheduler in it's own class. This class is in preparation of dynamic queue creation.

Also set library version to 2.0.0-SNAPSHOT to indicate the changes (and more that are in the pipeline) are major.