### PR TITLE
Added eager fetching option to queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Each type of work has it's own scheduler in the task manager and work independen
 
 ## Concepts
 
-* Task manager: The central application to set the priority of tasks.
-* Client: A process that creates tasks to be run.
-* Worker: A process that can run one or more tasks concurrently.
-* Task Queue: The queue on which clients place their tasks.
-Tasks Queues are grouped by the worker that can perform the task.
-* Worker Queue: A single queue per worker type on which all workers listen for tasks.
+- Task manager: The central application to set the priority of tasks.
+- Client: A process that creates tasks to be run.
+- Worker: A process that can run one or more tasks concurrently.
+- Task Queue: The queue on which clients place their tasks.
+  Tasks Queues are grouped by the worker that can perform the task.
+- Worker Queue: A single queue per worker type on which all workers listen for tasks.
 
 ## An Agile Approach
 
@@ -31,25 +31,25 @@ It guaranties that no matter how many tasks of a certain type are in the queue t
 ## Task Flow
 
 In the figure below an overview is given of how the clients, workers, queues and scheduler are connected.
-![Taskmanager scheduler](doc/taskmanager_scheduler.svg) 
-
+![Taskmanager scheduler](doc/taskmanager_scheduler.svg)
 
 The flow of a tasks is as follows:
+
 1. A client puts a task on the task type queue within the work group.
-The queue to put the job on depends on the type of task.
-For example a web interface calculation for Calculator is put on the queue `aerius.calculator.calculator_ui`.
-2. The taskmanagers listens to all client queues and takes a message from each queue if one is present.
+   The queue to put the job on depends on the type of task.
+   For example a web interface calculation for Calculator is put on the queue `aerius.calculator.calculator_ui`.
+2. The taskmanager listens to all client queues and takes a message from each queue if one is present.
 3. When a worker starts listing to the worker queue it opens a RabbbitMQ channel for each process in the worker that can handle tasks.
-For example a queue is named `aerius.worker.calculator`. Where `.worker` indicates that it's a worker queue.
+   For example a queue is named `aerius.worker.calculator`. Where `.worker` indicates that it's a worker queue.
 4. The taskmanager counts the number of worker channels and to determine the available capacity.
-This check is done with a fixed interval and the capacity is updated accordingly.
+   This check is done with a fixed interval and the capacity is updated accordingly.
 5. When a worker is available the taskmanager scheduler determines which task should be forwarded to a worker.
-This is based on priority and maximum load for a given worker type.
+   This is based on priority and maximum load for a given worker type.
 6. The task is then send to the worker and the taskmanager keeps track of this task.
 7. The taskmanager continues from step 2.
 8. Once the task is finished the worker sends a reply via the work reply queue, e.g. `aerius.worker.calculator.reply`.
 9. The taskmanager marks the tasks as finished and marks the worker as free.
-A new task can now be scheduled.
+   A new task can now be scheduled.
 
 ## Configuration
 
@@ -88,6 +88,7 @@ The json format of the configuration files is as follows:
 {
   "workerQueueName": "<type of the queue>",
   "durable" : <true|false>
+  "eagerFetch" : <true|false>
   "queueType": <classic|quorum|stream>
   "queues": [
     {
@@ -110,6 +111,12 @@ Some queues can have derived messages on the queue, that are recreated by the pa
 For these queues it would make sense to not make them durable.
 RabbitMQ will require less storage space/IOPS and be faster as it won't need to depend on disk I/O for these queues.
 
+The parameter `eagerFetch` indicates that all tasks on the queue will be prefetched.
+If not set or set to false it will only fetch a single task from the queue.
+By fetching all tasks from the queue as they arrive it can give different priorities to all tasks put on the same queue.
+Effectively it will give tasks on the same queue that have fewer tasks running on a worker a higher priority over tasks with more tasks running on a worker.
+This way of working will behave as if tasks with the same correlationId would have their own queue.
+
 The parameter `queueType` specifies the RabbitMQ type of the queues to be created.
 If set it will set the argument `x-queue-type` when declaring queues.
 If not set it will not set this arguments (used for backward compatibility, defaults to `classic`).
@@ -119,15 +126,17 @@ If `queueType` needs to be changed, the queues need to be deleted first.
 
 In `queues` there can be 1 or more queue configurations.
 Each queue configuration consists of 3 parameters:
-* `queueName`: The postfix of the client queue of which the task manager constructs the full queue name using the worker queue name.
-So `calculator_ui` becomes `aerius.ops.calculator_ui`, when the `workerQueueName` is `ops`.
-* `priority`: A positive int value determining the priority of the tasks.
-A higher number means a higher priority.
-* `maxCapacityUse`: A number between 0 and 1 that limits the amount of tasks that are concurrently run for the queue based on the available number of workers.
-For example if the value is `0.6` and there are `10` workers.
-This would mean a maximum of `6` workers will be given a tasks from this queue.
+
+- `queueName`: The postfix of the client queue of which the task manager constructs the full queue name using the worker queue name.
+  So `calculator_ui` becomes `aerius.ops.calculator_ui`, when the `workerQueueName` is `ops`.
+- `priority`: A positive int value determining the priority of the tasks.
+  A higher number means a higher priority.
+- `maxCapacityUse`: A number between 0 and 1 that limits the amount of tasks that are concurrently run for the queue based on the available number of workers.
+  For example if the value is `0.6` and there are `10` workers.
+  This would mean a maximum of `6` workers will be given a tasks from this queue.
 
 ### Overriding queue configuration
+
 Queue configuration for a specific worker can be overridden by creating an environment variable.
 When an environment variable exists with a matching worker queue name, that configuration is used instead of the file.
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskConsumerImpl.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/TaskConsumerImpl.java
@@ -30,7 +30,6 @@ import nl.aerius.taskmanager.adaptor.AdaptorFactory;
 import nl.aerius.taskmanager.adaptor.TaskMessageHandler;
 import nl.aerius.taskmanager.domain.ForwardTaskHandler;
 import nl.aerius.taskmanager.domain.Message;
-import nl.aerius.taskmanager.domain.MessageMetaData;
 import nl.aerius.taskmanager.domain.QueueConfig;
 import nl.aerius.taskmanager.domain.Task;
 import nl.aerius.taskmanager.domain.TaskConsumer;
@@ -46,7 +45,7 @@ public class TaskConsumerImpl implements TaskConsumer {
   private final ExecutorService executorService;
   private final String taskQueueName;
   private final ForwardTaskHandler forwardTaskHandler;
-  private final TaskMessageHandler<MessageMetaData, Message<MessageMetaData>> taskMessageHandler;
+  private final TaskMessageHandler<Message> taskMessageHandler;
 
   private boolean running = true;
 
@@ -76,7 +75,7 @@ public class TaskConsumerImpl implements TaskConsumer {
   }
 
   @Override
-  public void onMessageReceived(final Message<?> message) {
+  public void onMessageReceived(final Message message) {
     if (running) {
       final Task task = new Task(this);
 
@@ -94,19 +93,19 @@ public class TaskConsumerImpl implements TaskConsumer {
   }
 
   @Override
-  public void messageDelivered(final MessageMetaData messageMetaData) throws IOException {
+  public void messageDelivered(final Message messageMetaData) throws IOException {
     taskMessageHandler.messageDeliveredToWorker(messageMetaData);
   }
 
   /**
    * Inform the consumer the message delivery failed.
    *
-   * @param messageMetaData Meta data of the message that failed
+   * @param message the message that failed
    * @throws IOException
    */
   @Override
-  public void messageDeliveryFailed(final MessageMetaData messageMetaData) throws IOException {
-    taskMessageHandler.messageDeliveryToWorkerFailed(messageMetaData);
+  public void messageDeliveryFailed(final Message message) throws IOException {
+    taskMessageHandler.messageDeliveryToWorkerFailed(message);
   }
 
   /**
@@ -116,7 +115,7 @@ public class TaskConsumerImpl implements TaskConsumer {
    * @throws IOException
    */
   @Override
-  public void messageDeliveryAborted(final Message<MessageMetaData> message, final RuntimeException exception) throws IOException {
+  public void messageDeliveryAborted(final Message message, final RuntimeException exception) throws IOException {
     taskMessageHandler.messageDeliveryAborted(message, exception);
   }
 

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/TaskMessageHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/TaskMessageHandler.java
@@ -19,13 +19,12 @@ package nl.aerius.taskmanager.adaptor;
 import java.io.IOException;
 
 import nl.aerius.taskmanager.domain.Message;
-import nl.aerius.taskmanager.domain.MessageMetaData;
 import nl.aerius.taskmanager.domain.MessageReceivedHandler;
 
 /**
  * Interface for service receiving messages from a queue and pass them to the {@link MessageReceivedHandler}.
  */
-public interface TaskMessageHandler<E extends MessageMetaData, M extends Message<E>> {
+public interface TaskMessageHandler<M extends Message> {
 
   /**
    * Add handler to process message received handler.
@@ -51,14 +50,14 @@ public interface TaskMessageHandler<E extends MessageMetaData, M extends Message
    * @param message message delivered to the worker
    * @throws IOException connection errors
    */
-  void messageDeliveredToWorker(E message) throws IOException;
+  void messageDeliveredToWorker(M message) throws IOException;
 
   /**
    * Called when a message couldn't be delivered to a worker because the worker was not available.
    * @param message message not delivered
    * @throws IOException connection errors
    */
-  void messageDeliveryToWorkerFailed(E message) throws IOException;
+  void messageDeliveryToWorkerFailed(M message) throws IOException;
 
   /**
    * Called when something is wrong with the message and this should be reported to the sender. The message will not be

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/WorkerProducer.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/adaptor/WorkerProducer.java
@@ -41,7 +41,7 @@ public interface WorkerProducer {
    * @param message message to forward
    * @throws IOException connection errors
    */
-  void forwardMessage(final Message<?> message) throws IOException;
+  void forwardMessage(final Message message) throws IOException;
 
   /**
    * Shuts down this worker producer.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/Message.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/Message.java
@@ -19,16 +19,12 @@ package nl.aerius.taskmanager.domain;
 /**
  * Abstract data class containing the message send from clients to workers.
  */
-public abstract class Message<E extends MessageMetaData> {
-  private final E metaData;
+public abstract class Message {
 
-  protected Message(final E metaData) {
-    this.metaData = metaData;
-  }
-
-  public E getMetaData() {
-    return metaData;
-  }
+  /**
+   * @return The ID indicating messages that are correlated.
+   */
+  public abstract String getCorrelationId();
 
   /**
    * @return The unique ID for this message.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/MessageReceivedHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/MessageReceivedHandler.java
@@ -26,7 +26,7 @@ public interface MessageReceivedHandler {
    *
    * @param message the message
    */
-  void onMessageReceived(Message<?> message);
+  void onMessageReceived(Message message);
 
   /**
    * Called when the Consumer was shutdown.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/QueueConfig.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/QueueConfig.java
@@ -16,4 +16,10 @@
  */
 package nl.aerius.taskmanager.domain;
 
-public record QueueConfig(String queueName, boolean durable, RabbitMQQueueType queueType) {}
+public record QueueConfig(String queueName, boolean durable, boolean eagerFetch, RabbitMQQueueType queueType) {
+  @Override
+  public final String toString() {
+    return String.format("Queue name:%s, durable:%b, eagerFetch:%b, queueType:%s", queueName, durable, eagerFetch,
+        queueType == null ? "default" : queueType.type());
+  }
+}

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/Task.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/Task.java
@@ -23,10 +23,11 @@ import io.opentelemetry.context.Context;
  * instances. This data object keeps track of the taskconsumer that send the message.
  */
 public class Task {
-  private Message<?> data;
+  private Message data;
   private final TaskConsumer taskConsumer;
   private boolean alive = true;
   private Context context;
+  private TaskRecord taskRecord;
 
   public Task(final TaskConsumer taskConsumer) {
     this.taskConsumer = taskConsumer;
@@ -37,16 +38,21 @@ public class Task {
   }
 
   @SuppressWarnings("unchecked")
-  public <E extends MessageMetaData> Message<E> getMessage() {
-    return (Message<E>) data;
+  public Message getMessage() {
+    return data;
   }
 
   public TaskConsumer getTaskConsumer() {
     return taskConsumer;
   }
 
-  public void setData(final Message<?> data) {
+  public TaskRecord getTaskRecord() {
+    return taskRecord;
+  }
+
+  public void setData(final Message data) {
     this.data = data;
+    this.taskRecord = new TaskRecord(taskConsumer.getQueueName(), data.getCorrelationId(), data.getMessageId());
   }
 
   public void killTask() {

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/TaskConsumer.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/TaskConsumer.java
@@ -33,18 +33,18 @@ public interface TaskConsumer extends MessageReceivedHandler {
   /**
    * Inform the consumer the message delivery was successful.
    *
-   * @param messageMetaData Meta data of the message that that was successful
+   * @param message the message that was successful
    * @throws IOException
    */
-  void messageDelivered(final MessageMetaData messageMetaData) throws IOException;
+  void messageDelivered(final Message message) throws IOException;
 
   /**
    * Inform the consumer the message delivery failed.
    *
-   * @param messageMetaData Meta data of the message that failed
+   * @param message the message that failed
    * @throws IOException
    */
-  void messageDeliveryFailed(MessageMetaData messageMetaData) throws IOException;
+  void messageDeliveryFailed(Message message) throws IOException;
 
   /**
    * Inform the consumer the message delivery failed.
@@ -52,7 +52,7 @@ public interface TaskConsumer extends MessageReceivedHandler {
    * @param exception the exception with which the message failed
    * @throws IOException
    */
-  void messageDeliveryAborted(Message<MessageMetaData> message, RuntimeException exception) throws IOException;
+  void messageDeliveryAborted(Message message, RuntimeException exception) throws IOException;
 
   /**
    * Start the consumer.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/TaskRecord.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/TaskRecord.java
@@ -14,22 +14,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager;
-
-import nl.aerius.taskmanager.domain.WorkerUpdateHandler;
+package nl.aerius.taskmanager.domain;
 
 /**
- * Mock implementation of {@link WorkerUpdateHandler}.
+ * Object to keep key information of a task.
+ * @param queueName the queue the task came from
+ * @param correlationId id of the set of tasks
+ * @param id the unique id of the task
  */
-public class MockTaskFinishedHandler implements WorkerUpdateHandler {
-
-  @Override
-  public void onTaskFinished(final String queueName) {
-    //no-op
-  }
-
-  @Override
-  public void onWorkerPoolSizeChange(final int numberOfWorkers) {
-    //no-op
-  }
+public record TaskRecord(String queueName, String correlationId, String id) {
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/TaskSchedule.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/TaskSchedule.java
@@ -30,6 +30,8 @@ public class TaskSchedule<T extends TaskQueue> {
 
   private Boolean durable;
 
+  private Boolean eagerFetch;
+
   private RabbitMQQueueType queueType;
 
   private List<T> queues = new ArrayList<>();
@@ -56,6 +58,14 @@ public class TaskSchedule<T extends TaskQueue> {
 
   public boolean isDurable() {
     return !Boolean.FALSE.equals(durable);
+  }
+
+  public void setEagerFetch(final Boolean eagerFetch) {
+    this.eagerFetch = eagerFetch;
+  }
+
+  public boolean isEagerFetch() {
+    return Boolean.TRUE.equals(eagerFetch);
   }
 
   public RabbitMQQueueType getQueueType() {

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/WorkerUpdateHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/domain/WorkerUpdateHandler.java
@@ -23,9 +23,9 @@ public interface WorkerUpdateHandler {
 
   /**
    * Task has be processed by the worker pool and finished with results.
-   * @param queueName name of the queue the task that was finished on
+   * @param taskRecord record of the task that was finished
    */
-  void onTaskFinished(String queueName);
+  void onTaskFinished(TaskRecord taskRecord);
 
   /**
    * Called when the number of workers has been changed. The value passed is the new value.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessage.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessage.java
@@ -24,10 +24,11 @@ import nl.aerius.taskmanager.domain.Message;
 /**
  * RabbitMQ Message object.
  */
-public class RabbitMQMessage extends Message<RabbitMQMessageMetaData> {
+public class RabbitMQMessage extends Message {
   private final Channel channel;
   private final BasicProperties properties;
   private final byte[] body;
+  private final long deliveryTag;
 
   /**
    * Constructor
@@ -39,11 +40,19 @@ public class RabbitMQMessage extends Message<RabbitMQMessageMetaData> {
    * @param body The body of the original message.
    */
   public RabbitMQMessage(final String queueName, final Channel channel, final long deliveryTag, final BasicProperties properties, final byte[] body) {
-    super(new RabbitMQMessageMetaData(queueName, deliveryTag));
-
+    this.deliveryTag = deliveryTag;
     this.channel = channel;
     this.properties = properties;
     this.body = body == null ? new byte[0] : body.clone();
+  }
+
+  public long getDeliveryTag() {
+    return deliveryTag;
+  }
+
+  @Override
+  public String getCorrelationId() {
+    return properties.getCorrelationId();
   }
 
   @Override

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandler.java
@@ -38,7 +38,7 @@ import nl.aerius.taskmanager.mq.RabbitMQMessageConsumer.ConsumerCallback;
  * RabbitMQ implementation of a {@link TaskMessageHandler}. RabbitMQ will starts listening to the queue and when messages are received they are send
  * to the {@link MessageReceivedHandler}.
  */
-class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaData, RabbitMQMessage>, ConsumerCallback {
+class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessage>, ConsumerCallback {
 
   private static final Logger LOG = LoggerFactory.getLogger(RabbitMQMessageHandler.class);
 
@@ -115,12 +115,12 @@ class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaDa
   }
 
   @Override
-  public void messageDeliveredToWorker(final RabbitMQMessageMetaData message) throws IOException {
+  public void messageDeliveredToWorker(final RabbitMQMessage message) throws IOException {
     consumer.ack(message);
   }
 
   @Override
-  public void messageDeliveryToWorkerFailed(final RabbitMQMessageMetaData message) throws IOException {
+  public void messageDeliveryToWorkerFailed(final RabbitMQMessage message) throws IOException {
     consumer.nack(message);
   }
 
@@ -128,7 +128,7 @@ class RabbitMQMessageHandler implements TaskMessageHandler<RabbitMQMessageMetaDa
   public void messageDeliveryAborted(final RabbitMQMessage message, final RuntimeException exception) throws IOException {
     final WorkerResultSender sender = new WorkerResultSender(factory.getConnection().createChannel(), message.getProperties());
     sender.sendIntermediateResult(exception);
-    messageDeliveredToWorker(message.getMetaData());
+    messageDeliveredToWorker(message);
   }
 
   @Override

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducer.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducer.java
@@ -77,7 +77,7 @@ class RabbitMQWorkerProducer implements WorkerProducer {
   }
 
   @Override
-  public void forwardMessage(final Message<?> message) throws IOException {
+  public void forwardMessage(final Message message) throws IOException {
     final RabbitMQMessage rabbitMQMessage = (RabbitMQMessage) message;
     // Do we set the replyTo to something fake?
     // or do we expect worker to send instead of CC the message?

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/TaskScheduler.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/TaskScheduler.java
@@ -16,6 +16,7 @@
  */
 package nl.aerius.taskmanager.scheduler;
 
+import nl.aerius.taskmanager.domain.QueueConfig;
 import nl.aerius.taskmanager.domain.Task;
 import nl.aerius.taskmanager.domain.TaskQueue;
 import nl.aerius.taskmanager.domain.TaskSchedule;
@@ -71,10 +72,10 @@ public interface TaskScheduler<T extends TaskQueue> extends WorkerUpdateHandler 
     /**
      * Create a new scheduler.
      *
-     * @param workerQueueName the worker queue the scheduler is creatd for
+     * @param queueConfig the queue configuration the scheduler is created for
      * @return new task scheduler
      */
-    TaskScheduler<T> createScheduler(String workerQueueName);
+    TaskScheduler<T> createScheduler(QueueConfig queueConfig);
 
     /**
      * Returns the handler that persists the scheduler configurations.

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/EagerFetchPriorityQueueMapKeyMapper.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/EagerFetchPriorityQueueMapKeyMapper.java
@@ -14,16 +14,24 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager.domain;
+package nl.aerius.taskmanager.scheduler.priorityqueue;
 
-public class MessageMetaData {
-  private final String queueName;
+import nl.aerius.taskmanager.domain.TaskRecord;
 
-  protected MessageMetaData(final String queueName) {
-    this.queueName = queueName;
+/**
+ * Maps a task record to a key that groups all tasks with the same correlationId.
+ */
+class EagerFetchPriorityQueueMapKeyMapper extends PriorityQueueMapKeyMapper {
+
+  private static final String KEY_SPLITTER = "#";
+
+  @Override
+  public String key(final TaskRecord taskRecord) {
+    return taskRecord.queueName() + KEY_SPLITTER + taskRecord.correlationId();
   }
 
-  public String getQueueName() {
-    return queueName;
+  @Override
+  public String queueName(final String key) {
+    return key.split(KEY_SPLITTER)[0];
   }
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/GroupedPriorityQueue.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/GroupedPriorityQueue.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.taskmanager.scheduler.priorityqueue;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.stream.Stream;
+
+import nl.aerius.taskmanager.domain.Task;
+
+/**
+ * The {@link GroupedPriorityQueue} is a priority queue that holds back tasks with the same correlationId from the main queue.
+ * When a task with the same correlationId is added to the queue it parks it on a separate internal queue.
+ * When the first task added is polled from the queue, it will take the next task from the internal queue and puts it on the main queue.
+ *
+ * The idea behind this queue is to make it possible to have a priority system where tasks on the same queue but with different correlationId can
+ * be priorities depending on how many of tasks for a specific correlationId are already being processed on a worker.
+ */
+class GroupedPriorityQueue implements Queue<Task> {
+
+  private final Queue<Task> queue;
+  private final Map<String, Queue<Task>> groupedQueue = new HashMap<>();
+
+  public GroupedPriorityQueue(final int initialSize, final Comparator<Task> comparator) {
+    queue = new PriorityQueue<>(initialSize, comparator);
+  }
+
+  @Override
+  public synchronized boolean add(final Task task) {
+    final String correlationId = task.getTaskRecord().correlationId();
+
+    if (queue.stream().anyMatch(t -> t.getTaskRecord().correlationId().equals(correlationId))) {
+      groupedQueue.computeIfAbsent(correlationId, k -> new ArrayDeque<>()).add(task);
+    } else {
+      queue.add(task);
+    }
+    return true;
+  }
+
+  @Override
+  public Task peek() {
+    return queue.peek();
+  }
+
+  @Override
+  public synchronized Task poll() {
+    final Task task = queue.poll();
+    final String correlationId = task.getTaskRecord().correlationId();
+    final Queue<Task> tasksQueue = groupedQueue.get(correlationId);
+
+    if (tasksQueue != null) {
+      queue.add(tasksQueue.poll());
+      if (tasksQueue.isEmpty()) {
+        groupedQueue.remove(correlationId);
+      }
+    }
+    return task;
+  }
+
+  @Override
+  public Stream<Task> stream() {
+    return queue.stream();
+  }
+
+  // Only methods actually used in our code are implemented. All other methods will throw an exception if used as a remainder if the code would start
+  // using these methods they need to be implemented.
+
+  @Override
+  public boolean addAll(final Collection<? extends Task> arg0) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean contains(final Object arg0) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean containsAll(final Collection<?> arg0) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean isEmpty() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public Iterator<Task> iterator() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean remove(final Object arg0) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean removeAll(final Collection<?> arg0) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean retainAll(final Collection<?> arg0) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public int size() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public Object[] toArray() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public <T> T[] toArray(final T[] arg0) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public Task element() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean offer(final Task arg0) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public Task remove() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+}

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/GroupedPriorityQueue.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/GroupedPriorityQueue.java
@@ -34,7 +34,7 @@ import nl.aerius.taskmanager.domain.Task;
  * When the first task added is polled from the queue, it will take the next task from the internal queue and puts it on the main queue.
  *
  * The idea behind this queue is to make it possible to have a priority system where tasks on the same queue but with different correlationId can
- * be priorities depending on how many of tasks for a specific correlationId are already being processed on a worker.
+ * be prioritised depending on how many of tasks for a specific correlationId are already being processed on a worker.
  */
 class GroupedPriorityQueue implements Queue<Task> {
 
@@ -82,7 +82,7 @@ class GroupedPriorityQueue implements Queue<Task> {
     return queue.stream();
   }
 
-  // Only methods actually used in our code are implemented. All other methods will throw an exception if used as a remainder if the code would start
+  // Only methods actually used in our code are implemented. All other methods will throw an exception if used as a reminder if the code would start
   // using these methods they need to be implemented.
 
   @Override

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityQueueMapKeyMapper.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityQueueMapKeyMapper.java
@@ -14,28 +14,20 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.aerius.taskmanager.mq;
+package nl.aerius.taskmanager.scheduler.priorityqueue;
 
-import nl.aerius.taskmanager.domain.MessageMetaData;
+import nl.aerius.taskmanager.domain.TaskRecord;
 
 /**
- * Metadata data of a RabbitMQ message.
+ * Key mapper to group tasks per queue. Used for scheduling tasks by fetching 1 message from the queue at a time.
  */
-public class RabbitMQMessageMetaData extends MessageMetaData {
-  private final long deliveryTag;
+public class PriorityQueueMapKeyMapper {
 
-  /**
-   * Constructor
-   *
-   * @param queueName Name of the queue this meta data related to
-   * @param deliveryTag RabbitMQ tag used to ack or nack a message to the RabbitMQ queue
-   */
-  public RabbitMQMessageMetaData(final String queueName, final long deliveryTag) {
-    super(queueName);
-    this.deliveryTag = deliveryTag;
+  public String key(final TaskRecord taskRecord) {
+    return taskRecord.queueName();
   }
 
-  public long getDeliveryTag() {
-    return deliveryTag;
+  public String queueName(final String key) {
+    return key;
   }
 }

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTask.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTask.java
@@ -16,31 +16,29 @@
  */
 package nl.aerius.taskmanager;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 import java.util.UUID;
 
-import nl.aerius.taskmanager.domain.Message;
 import nl.aerius.taskmanager.domain.Task;
 import nl.aerius.taskmanager.domain.TaskConsumer;
-import nl.aerius.taskmanager.mq.RabbitMQMessageMetaData;
+import nl.aerius.taskmanager.mq.RabbitMQMessage;
 
 /**
  * Mock implementation of {@link Task}.
  */
 public class MockTask extends Task {
-  private final String id = UUID.randomUUID().toString();
 
-  public MockTask(final TaskConsumer taskConsumer, final String queueName) {
+  public MockTask(final TaskConsumer taskConsumer) {
+    this(taskConsumer, UUID.randomUUID().toString());
+  }
+
+  public MockTask(final TaskConsumer taskConsumer, final String id) {
     super(taskConsumer);
-    setData(new Message<RabbitMQMessageMetaData>(new RabbitMQMessageMetaData(queueName, 2)) {
-      @Override
-      public RabbitMQMessageMetaData getMetaData() {
-        return super.getMetaData();
-      }
+    final RabbitMQMessage message = mock(RabbitMQMessage.class);
 
-      @Override
-      public String getMessageId() {
-        return id;
-      }
-    });
+    doReturn(id).when(message).getMessageId();
+    setData(message);
   }
 }

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTaskMessageHandler.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTaskMessageHandler.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 
 import nl.aerius.taskmanager.adaptor.TaskMessageHandler;
 import nl.aerius.taskmanager.domain.Message;
-import nl.aerius.taskmanager.domain.MessageMetaData;
 import nl.aerius.taskmanager.domain.MessageReceivedHandler;
 
 /**
@@ -28,8 +27,8 @@ import nl.aerius.taskmanager.domain.MessageReceivedHandler;
  */
 public class MockTaskMessageHandler implements TaskMessageHandler {
 
-  private MessageMetaData failedMessage;
-  private MessageMetaData message;
+  private Message failedMessage;
+  private Message message;
   private Message abortedMessage;
 
   @Override
@@ -48,16 +47,16 @@ public class MockTaskMessageHandler implements TaskMessageHandler {
   }
 
   @Override
-  public void messageDeliveredToWorker(final MessageMetaData message) throws IOException {
+  public void messageDeliveredToWorker(final Message message) throws IOException {
     this.message = message;
   }
 
-  public MessageMetaData getMessage() {
+  public Message getMessage() {
     return message;
   }
 
   @Override
-  public void messageDeliveryToWorkerFailed(final MessageMetaData message) throws IOException {
+  public void messageDeliveryToWorkerFailed(final Message message) throws IOException {
     failedMessage = message;
   }
 
@@ -70,7 +69,7 @@ public class MockTaskMessageHandler implements TaskMessageHandler {
     return abortedMessage;
   }
 
-  public MessageMetaData getFailedMessage() {
+  public Message getFailedMessage() {
     return failedMessage;
   }
 

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTaskScheduler.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/MockTaskScheduler.java
@@ -21,7 +21,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import nl.aerius.taskmanager.domain.PriorityTaskQueue;
 import nl.aerius.taskmanager.domain.PriorityTaskSchedule;
+import nl.aerius.taskmanager.domain.QueueConfig;
 import nl.aerius.taskmanager.domain.Task;
+import nl.aerius.taskmanager.domain.TaskRecord;
 import nl.aerius.taskmanager.scheduler.TaskScheduler;
 import nl.aerius.taskmanager.scheduler.priorityqueue.PriorityTaskSchedulerFileHandler;
 
@@ -58,7 +60,7 @@ public class MockTaskScheduler implements TaskScheduler<PriorityTaskQueue> {
   }
 
   @Override
-  public void onTaskFinished(final String queueName) {
+  public void onTaskFinished(final TaskRecord taskRecord) {
     // Not used
   }
 
@@ -71,7 +73,7 @@ public class MockTaskScheduler implements TaskScheduler<PriorityTaskQueue> {
     private final PriorityTaskSchedulerFileHandler handler = new PriorityTaskSchedulerFileHandler();
 
     @Override
-    public MockTaskScheduler createScheduler(final String workerQueueName) {
+    public MockTaskScheduler createScheduler(final QueueConfig queueConfig) {
       return new MockTaskScheduler();
     }
 

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandlerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQMessageHandlerTest.java
@@ -62,7 +62,7 @@ class RabbitMQMessageHandlerTest extends AbstractRabbitMQTest {
   @Timeout(10000)
   void testMessageReceivedHandler() throws IOException, InterruptedException {
     final byte[] receivedBody = "4321".getBytes();
-    final TaskMessageHandler tmh = adapterFactory.createTaskMessageHandler(new QueueConfig(taskQueueName, false, null));
+    final TaskMessageHandler tmh = adapterFactory.createTaskMessageHandler(new QueueConfig(taskQueueName, false, false, null));
     final Semaphore lock = new Semaphore(0);
     final DataDock data = new DataDock();
     tmh.start();
@@ -108,7 +108,7 @@ class RabbitMQMessageHandlerTest extends AbstractRabbitMQTest {
     final AtomicInteger shutdownCallsCounter = new AtomicInteger();
 
     final MessageReceivedHandler mockMessageReceivedHandler = mock(MessageReceivedHandler.class);
-    final TaskMessageHandler tmh = adapterFactory.createTaskMessageHandler(new QueueConfig(taskQueueName, false, null));
+    final TaskMessageHandler tmh = adapterFactory.createTaskMessageHandler(new QueueConfig(taskQueueName, false, false, null));
 
     ((RabbitMQMessageHandler) tmh).setRetryTimeMilliseconds(1L);
     doAnswer(invoke -> null).when(mockChannel).addShutdownListener(shutdownListenerCaptor.capture());

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducerTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/mq/RabbitMQWorkerProducerTest.java
@@ -48,7 +48,7 @@ class RabbitMQWorkerProducerTest extends AbstractRabbitMQTest {
   void testForwardMessage() throws IOException, InterruptedException {
     final byte[] sendBody = "4321".getBytes();
 
-    final WorkerProducer wp = adapterFactory.createWorkerProducer(new QueueConfig(WORKER_QUEUE_NAME, false, null));
+    final WorkerProducer wp = adapterFactory.createWorkerProducer(new QueueConfig(WORKER_QUEUE_NAME, false, false, null));
     wp.start();
     final BasicProperties bp = new BasicProperties();
     wp.forwardMessage(new RabbitMQMessage(WORKER_QUEUE_NAME, null, 4321, bp, sendBody) {

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/scheduler/priorityqueue/GroupedPriorityQueueTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/scheduler/priorityqueue/GroupedPriorityQueueTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.taskmanager.scheduler.priorityqueue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import nl.aerius.taskmanager.domain.Message;
+import nl.aerius.taskmanager.domain.Task;
+import nl.aerius.taskmanager.domain.TaskConsumer;
+
+/**
+ * Test class for {@link GroupedPriorityQueue}.
+ */
+class GroupedPriorityQueueTest {
+
+  private GroupedPriorityQueue queue;
+
+  @Test
+  void testPoll() {
+    queue = new GroupedPriorityQueue(10, (a, b) -> 0);
+    final Task task1 = mockTask("1");
+    final Task task2 = mockTask("1");
+    final Task task3 = mockTask("2");
+    final Task task4 = mockTask("2");
+    final Task task5 = mockTask("1");
+    queue.add(task1);
+    queue.add(task2);
+    queue.add(task3);
+    queue.add(task4);
+    queue.add(task5);
+
+    assertNotNull(queue.peek(), "Queue should have task at the queue.");
+    assertEquals(task1, queue.poll(), "Poll should return first task added.");
+    assertEquals(task3, queue.poll(), "Poll should return first task of task with correlationId 2.");
+    assertEquals(task2, queue.poll(), "Poll should return second task of correlationId 1, because it's at the front of the queue.");
+    assertEquals(task4, queue.poll(), "Poll should return second task of correlationId 2, because it should be at front of the queue.");
+    assertEquals(task5, queue.poll(), "Poll should return last added task.");
+  }
+
+  private static Task mockTask(final String correlationId) {
+    final TaskConsumer taskConsumer = mock(TaskConsumer.class);
+    final Task task = new Task(taskConsumer);
+    final Message data = mock(Message.class);
+    doReturn(correlationId).when(data).getCorrelationId();
+
+    task.setData(data);
+    return task;
+  }
+}


### PR DESCRIPTION
Eager fetching will get all messages from the queue to be send to a worker instead of 1 message at a time. It still acks the message when actually send to the worker. With eager fetching it will be possible to apply priority to messages on the same queue. This way we can get a more fair scheduler. Since it will give higher priority to messages from the same job that have less tasks already running on a worker. With fairer priority the time a calculation takes should become more consist on average. Getting all messages from the queue can take some more memory, but with plans for a new way to put messages on the queue the actual messages put on the queues should become limited.

This new feature is backward compatible. As long as eagerFetch is not enabled it will work as before.

Some other refactorings:
- Removed the locking of the queues from TaskDispatcher. For eager fetching no locking should be done. But it turned out RabbitMQ already does the locking via QoS value. Therefore the locking was actually redundant.
- Removed MessageMetaData. It's only used for RabbitMQ deliveryTag that can be put int RabbitMQMessage, making the overall code simpler.
- Refactored some mocking classes by using Mockito instead of mocked class.