### PR TITLE
For metric always record value even if 0

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/PerformanceMetricsReporter.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/PerformanceMetricsReporter.java
@@ -170,9 +170,9 @@ public class PerformanceMetricsReporter implements WorkerFinishedHandler {
     final DurationMetricValue metric = metrics.process();
     final int count = metric.count();
 
+    histogram.record(count, metrics.getAttributes());
+    waitHistorgram.record(metric.avgDuration(), metrics.getAttributes());
     if (count > 0) {
-      histogram.record(count, metrics.getAttributes());
-      waitHistorgram.record(metric.avgDuration(), metrics.getAttributes());
       LOG.debug("{} for {}: {} ms/task (#tasks: {})", prefixText, name, metric.avgDuration(), count);
     }
   }


### PR DESCRIPTION
Otherwise it keeps the last known value.
Do guard the logging, as we're not interested in having a value in debug when no activity (e.g. count = 0)