### PR TITLE
Changed Historgram metrics to gauge metrics

### DIFF
--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/metrics/PerformanceMetricsReporterTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/metrics/PerformanceMetricsReporterTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -43,8 +44,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.opentelemetry.api.metrics.DoubleGauge;
 import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
-import io.opentelemetry.api.metrics.DoubleHistogram;
-import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.Meter;
 
 import nl.aerius.taskmanager.adaptor.WorkerProducer.WorkerMetrics;
@@ -61,12 +60,11 @@ class PerformanceMetricsReporterTest {
   private static final String QUEUE_1 = "queue 1";
   private static final String QUEUE_2 = "queue 2";
 
-  private final Map<String, DoubleHistogram> mockedHistograms = new HashMap<>();
+  private final Map<String, DoubleGauge> mockedGauges = new HashMap<>();
 
   @Mock Meter mockedMeter;
   @Mock WorkerMetrics workMetrics;
   @Mock ScheduledExecutorService scheduledExecutorService;
-  @Mock DoubleGauge mockGauge;
   @Captor ArgumentCaptor<Runnable> methodCaptor;
   @Captor ArgumentCaptor<Double> durationCaptor;
 
@@ -74,18 +72,15 @@ class PerformanceMetricsReporterTest {
 
   @BeforeEach
   void beforeEach() {
-    doAnswer(inv -> {
-      final DoubleHistogramBuilder mockBuilder = mock(DoubleHistogramBuilder.class);
-      final DoubleHistogram histogram = mock(DoubleHistogram.class);
-      doReturn(mockBuilder).when(mockBuilder).setDescription(any());
-      doReturn(histogram).when(mockBuilder).build();
-      mockedHistograms.put(inv.getArgument(0, String.class), histogram);
-      return mockBuilder;
-    }).when(mockedMeter).histogramBuilder(any());
     final DoubleGaugeBuilder mockGaugeBuilder = mock(DoubleGaugeBuilder.class);
-    doReturn(mockGaugeBuilder).when(mockedMeter).gaugeBuilder(any());
-    doReturn(mockGaugeBuilder).when(mockGaugeBuilder).setDescription(any());
-    doReturn(mockGauge).when(mockGaugeBuilder).build();
+    doAnswer(inv -> {
+      final DoubleGauge gauge = mock(DoubleGauge.class);
+      doReturn(mockGaugeBuilder).when(mockGaugeBuilder).setDescription(any());
+      doReturn(gauge).when(mockGaugeBuilder).build();
+      mockedGauges.put(inv.getArgument(0, String.class), gauge);
+      return mockGaugeBuilder;
+    }).when(mockedMeter).gaugeBuilder(any());
+    lenient().doReturn(mockGaugeBuilder).when(mockGaugeBuilder).setDescription(any());
     reporter = new PerformanceMetricsReporter(scheduledExecutorService, QUEUE_GROUP_NAME, mockedMeter, workMetrics);
     verify(scheduledExecutorService).scheduleWithFixedDelay(methodCaptor.capture(), anyLong(), anyLong(), any(TimeUnit.class));
   }
@@ -96,12 +91,12 @@ class PerformanceMetricsReporterTest {
     reporter.onWorkDispatched("1", createMap(QUEUE_1, 100L));
     reporter.onWorkDispatched("2", createMap(QUEUE_2, 200L));
     methodCaptor.getValue().run();
-    verify(mockedHistograms.get("aer.taskmanager.dispatched")).record(eq(2.0), any());
-    verify(mockedHistograms.get("aer.taskmanager.dispatched.wait")).record(durationCaptor.capture(), any());
-    verify(mockedHistograms.get("aer.taskmanager.dispatched.queue")).record(eq(2.0), any());
-    verify(mockedHistograms.get("aer.taskmanager.dispatched.queue.wait")).record(durationCaptor.capture(), any());
+    verify(mockedGauges.get("aer.taskmanager.dispatched")).set(eq(2.0), any());
+    verify(mockedGauges.get("aer.taskmanager.dispatched.wait")).set(durationCaptor.capture(), any());
+    verify(mockedGauges.get("aer.taskmanager.dispatched.queue")).set(eq(2.0), any());
+    verify(mockedGauges.get("aer.taskmanager.dispatched.queue.wait")).set(durationCaptor.capture(), any());
     durationCaptor.getAllValues()
-        .forEach(v -> assertTrue(v > 99.0, "Duration should report at least 100.0 as it is the offset of the start time, but was " + v));
+    .forEach(v -> assertTrue(v > 99.0, "Duration should report at least 100.0 as it is the offset of the start time, but was " + v));
   }
 
   @Test
@@ -110,12 +105,12 @@ class PerformanceMetricsReporterTest {
     reporter.onWorkerFinished("1", createMap(QUEUE_1, 100L));
     reporter.onWorkerFinished("2", createMap(QUEUE_2, 200L));
     methodCaptor.getValue().run();
-    verify(mockedHistograms.get("aer.taskmanager.work")).record(eq(2.0), any());
-    verify(mockedHistograms.get("aer.taskmanager.work.duration")).record(durationCaptor.capture(), any());
-    verify(mockedHistograms.get("aer.taskmanager.work.queue")).record(eq(2.0), any());
-    verify(mockedHistograms.get("aer.taskmanager.work.queue.duration")).record(durationCaptor.capture(), any());
+    verify(mockedGauges.get("aer.taskmanager.work")).set(eq(2.0), any());
+    verify(mockedGauges.get("aer.taskmanager.work.duration")).set(durationCaptor.capture(), any());
+    verify(mockedGauges.get("aer.taskmanager.work.queue")).set(eq(2.0), any());
+    verify(mockedGauges.get("aer.taskmanager.work.queue.duration")).set(durationCaptor.capture(), any());
     durationCaptor.getAllValues()
-        .forEach(v -> assertTrue(v > 99.0, "Duration should report at least 100.0 as it is the offset of the start time, but was " + v));
+    .forEach(v -> assertTrue(v > 99.0, "Duration should report at least 100.0 as it is the offset of the start time, but was " + v));
   }
 
   @Test
@@ -124,9 +119,9 @@ class PerformanceMetricsReporterTest {
     reporter.onWorkDispatched("1", createMap(QUEUE_1, 100L));
     reporter.onWorkDispatched("2", createMap(QUEUE_2, 200L));
     methodCaptor.getValue().run();
-    Thread.sleep(10); // Add a bit of delay to get sime time frame between these 2 run calls.
+    Thread.sleep(10); // Add a bit of delay to get some time frame between these 2 run calls.
     methodCaptor.getValue().run();
-    verify(mockGauge, times(2)).set(durationCaptor.capture(), any());
+    verify(mockedGauges.get("aer.taskmanager.work.load") , times(2)).set(durationCaptor.capture(), any());
     assertEquals(50.0, durationCaptor.getAllValues().get(1));
   }
 


### PR DESCRIPTION
Historgram metrics show up with past taking into account, not given an accurate value of the state at the moment these values are not helpful currently. Therefore they are changed to gauge metrics. Also because the values itself are already aggregated in the taskmanager it does make more sense to have gauge values.