### PR TITLE
Fixes: retry task directly, instead of readd, and guard agains tnull

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityQueueMap.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityQueueMap.java
@@ -61,7 +61,7 @@ class PriorityQueueMap<K extends PriorityQueueMapKeyMapper> {
   public void decrementOnWorker(final TaskRecord taskRecord) {
     final String trKey = key(taskRecord);
 
-    if (tasksOnWorkersPerQueue.get(trKey).decrementAndGet() == 0) {
+    if (Optional.ofNullable(tasksOnWorkersPerQueue.get(trKey)).map(v -> v.decrementAndGet() == 0).orElse(false)) {
       tasksOnWorkersPerQueue.remove(trKey);
     }
   }


### PR DESCRIPTION
- Instead of adding a task back to the scheduler retry it in the loop. This because some other metrics are tracked on tasks, and these are messed up by readding it (unless we would implement some more logic to do an actual re-add to the scheduler. But in that case just do it in the loop makes more sense).
- Added extra null guard for safety.