### PR TITLE
Improvements to metrics reporting

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/OpenTelemetryMetrics.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/OpenTelemetryMetrics.java
@@ -39,36 +39,36 @@ public final class OpenTelemetryMetrics {
 
   public static Attributes workerAttributes(final String workerType) {
     return Attributes.builder()
-        .put(WORKER_TYPE_ATTRIBUTE, workerIdentifier(workerType))
+        .put(WORKER_TYPE_ATTRIBUTE, onlyLastPart(workerType))
         .build();
   }
 
   public static Attributes workerAttributes(final String workerType, final String atttributeName, final String attributeValue) {
     return Attributes.builder()
-        .put(WORKER_TYPE_ATTRIBUTE, workerIdentifier(workerType))
+        .put(WORKER_TYPE_ATTRIBUTE, onlyLastPart(workerType))
         .put(atttributeName, attributeValue)
         .build();
   }
 
   public static Attributes queueAttributes(final String workerQueueName, final String queueName) {
     return Attributes.builder()
-        .put(WORKER_TYPE_ATTRIBUTE, workerIdentifier(workerQueueName))
-        .put(QUEUE_ATTRIBUTE, queueName)
+        .put(WORKER_TYPE_ATTRIBUTE, onlyLastPart(workerQueueName))
+        .put(QUEUE_ATTRIBUTE, onlyLastPart(queueName))
         .build();
   }
 
   public static Attributes queueAttributes(final String workerQueueName, final String queueName, final String atttributeName,
       final String attributeValue) {
     return Attributes.builder()
-        .put(WORKER_TYPE_ATTRIBUTE, workerIdentifier(workerQueueName))
-        .put(QUEUE_ATTRIBUTE, queueName)
+        .put(WORKER_TYPE_ATTRIBUTE, onlyLastPart(workerQueueName))
+        .put(QUEUE_ATTRIBUTE, onlyLastPart(queueName))
         .put(atttributeName, attributeValue)
         .build();
   }
 
-  private static String workerIdentifier(final String workerQueueName) {
-    final int workerTypeIndex = workerQueueName.lastIndexOf('.');
+  private static String onlyLastPart(final String name) {
+    final int lastIndex = name.lastIndexOf('.');
 
-    return (workerTypeIndex > 0 ? workerQueueName.substring(workerTypeIndex + 1) : workerQueueName).toLowerCase(Locale.ROOT);
+    return (lastIndex < 0 ? name : name.substring(lastIndex + 1)).toLowerCase(Locale.ROOT);
   }
 }

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/TaskManagerUsageMetricsWrapper.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/TaskManagerUsageMetricsWrapper.java
@@ -33,7 +33,7 @@ public class TaskManagerUsageMetricsWrapper {
     rabbitMQUsageMetrics = new UsageMetricsWrapper(meter, "aer.rabbitmq", true);
     workerPoolUsageMetrics = new UsageMetricsWrapper(meter, "aer.taskmanager.workerpool", false);
     taskManagerUsageMetrics = new UsageMetricsWrapper(meter, "aer.taskmanager", false);
-    loadUsageMetricsReporter = new UsageMetricsReporter(meter, "aer.taskmanager.worker.load", "");
+    loadUsageMetricsReporter = new UsageMetricsReporter(meter, "aer.taskmanager.worker.load", "Report average worker load");
   }
 
   /**

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/UsageMetricsWrapper.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/UsageMetricsWrapper.java
@@ -30,8 +30,8 @@ class UsageMetricsWrapper {
 
   public UsageMetricsWrapper(final Meter meter, final String metricPrefix, final boolean hasWaiting) {
     this.hasWaiting = hasWaiting;
-    limitReporter = new UsageMetricsReporter(meter, metricPrefix + ".worker.limit", "");
-    usageReporter = new UsageMetricsReporter(meter, metricPrefix + ".worker.usage", "");
+    limitReporter = new UsageMetricsReporter(meter, metricPrefix + ".worker.limit", "Report nunber of workers available");
+    usageReporter = new UsageMetricsReporter(meter, metricPrefix + ".worker.usage", "Report worker usage");
   }
 
   public void add(final UsageMetricsProvider provider) {

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerMetrics.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerMetrics.java
@@ -36,7 +36,7 @@ class PriorityTaskSchedulerMetrics {
   @Deprecated
   private static final String METRIC_PREFIX_LEGACY = "aer.taskmanager.running_client_size";
   private static final String METRIC_PREFIX = "aer.taskmanager.client.queue";
-  private static final String DESCRIPTION = "Number of tasks running for the client queue ";
+  private static final String DESCRIPTION = "Number of tasks running on client queues";
 
   private final Map<String, ObservableDoubleGauge> metrics = new HashMap<>();
   private final Map<String, ObservableDoubleGauge> usageMetrics = new HashMap<>();
@@ -52,13 +52,13 @@ class PriorityTaskSchedulerMetrics {
   public void addMetric(final IntSupplier countSupplier, final String workerQueueName, final String clientQueueName) {
     metrics.put(clientQueueName, OpenTelemetryMetrics.METER
         .gaugeBuilder(METRIC_PREFIX_LEGACY)
-        .setDescription(DESCRIPTION + clientQueueName)
+        .setDescription(DESCRIPTION)
         .buildWithCallback(
             result -> result.record(countSupplier.getAsInt(),
                 OpenTelemetryMetrics.queueAttributes(workerQueueName, clientQueueName, "state", "used"))));
     metrics.put(clientQueueName, OpenTelemetryMetrics.METER
         .gaugeBuilder(METRIC_PREFIX)
-        .setDescription(DESCRIPTION + clientQueueName)
+        .setDescription(DESCRIPTION)
         .buildWithCallback(
             result -> result.record(countSupplier.getAsInt(),
                 OpenTelemetryMetrics.queueAttributes(workerQueueName, clientQueueName, "state", "used"))));

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/metrics/OpenTelemetryMetricsTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/metrics/OpenTelemetryMetricsTest.java
@@ -36,7 +36,7 @@ class OpenTelemetryMetricsTest {
 
   @Test
   void testQueueAttributes() {
-    final Attributes attributes = OpenTelemetryMetrics.queueAttributes("aer.worker.OPS", "calculator");
+    final Attributes attributes = OpenTelemetryMetrics.queueAttributes("aer.worker.OPS", "aerius.worker.calculator");
 
     assertEquals("ops", attributes.get(OpenTelemetryMetrics.WORKER_TYPE_ATTRIBUTE), "Should have expected worker type attribute");
     assertEquals("calculator", attributes.get(OpenTelemetryMetrics.QUEUE_ATTRIBUTE), "Should have expected queue name attribute");

--- a/source/taskmanager/src/test/java/nl/aerius/taskmanager/metrics/OpenTelemetryMetricsTest.java
+++ b/source/taskmanager/src/test/java/nl/aerius/taskmanager/metrics/OpenTelemetryMetricsTest.java
@@ -36,9 +36,9 @@ class OpenTelemetryMetricsTest {
 
   @Test
   void testQueueAttributes() {
-    final Attributes attributes = OpenTelemetryMetrics.queueAttributes("aer.worker.OPS", "aerius.worker.calculator");
+    final Attributes attributes = OpenTelemetryMetrics.queueAttributes("aer.worker.OPS", "aer.calculator.calculator_ui_small");
 
     assertEquals("ops", attributes.get(OpenTelemetryMetrics.WORKER_TYPE_ATTRIBUTE), "Should have expected worker type attribute");
-    assertEquals("calculator", attributes.get(OpenTelemetryMetrics.QUEUE_ATTRIBUTE), "Should have expected queue name attribute");
+    assertEquals("calculator_ui_small", attributes.get(OpenTelemetryMetrics.QUEUE_ATTRIBUTE), "Should have expected queue name attribute");
   }
 }


### PR DESCRIPTION
- Striped first part of queue name attribute; only last part is relevant as rest is redundant (also makes viewing in graphana cleaner as only last part will be shown).
- Description of metrics that are registered multiple times with different attributes should be the same for each registration otherwise Otel will report warning.
- Added missing descriptions to some of the metrics.