### PR TITLE
Fix for adding usage metrics

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/UsageMetricsReporter.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/UsageMetricsReporter.java
@@ -16,8 +16,11 @@
  */
 package nl.aerius.taskmanager.metrics;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.DoubleSupplier;
 
 import org.slf4j.Logger;
@@ -38,7 +41,7 @@ class UsageMetricsReporter {
 
   private record UsageMetric(DoubleSupplier metricSupplier, Attributes attributes) {}
 
-  private final Map<String, UsageMetric> metricsMap = new HashMap<>();
+  private final Map<String, List<UsageMetric>> metricsMap = new HashMap<>();
   private final ObservableDoubleGauge gauge;
 
   public UsageMetricsReporter(final Meter meter, final String metricName, final String description) {
@@ -49,12 +52,12 @@ class UsageMetricsReporter {
   }
 
   private void recordMetrics(final ObservableDoubleMeasurement measurement) {
-    for (final Map.Entry<String, UsageMetric> entry : metricsMap.entrySet()) {
-      final UsageMetric metric = entry.getValue();
+    for (final Entry<String, List<UsageMetric>> workerMetrics : metricsMap.entrySet()) {
+      for (final UsageMetric metric : workerMetrics.getValue()) {
 
-      measurement.record(metric.metricSupplier().getAsDouble(), metric.attributes());
+        measurement.record(metric.metricSupplier().getAsDouble(), metric.attributes());
+      }
     }
-    LOG.debug("Workload for {}", measurement);
   }
 
   /**
@@ -65,7 +68,7 @@ class UsageMetricsReporter {
    * @param attributes attributes for the metric
    */
   public void addMetrics(final String workerQueueName, final DoubleSupplier metricSupplier, final Attributes attributes) {
-    metricsMap.put(workerQueueName, new UsageMetric(metricSupplier, attributes));
+    metricsMap.computeIfAbsent(workerQueueName, k -> new ArrayList<>()).add(new UsageMetric(metricSupplier, attributes));
   }
 
   /**

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerMetrics.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerMetrics.java
@@ -65,10 +65,11 @@ class PriorityTaskSchedulerMetrics {
   }
 
   /**
+   * Adds collecting metrics to count the number of tasks waiting on the client queue.
    *
-   * @param countSupplier
-   * @param workerQueueName
-   * @param clientQueueName
+   * @param countSupplier supplier that returns the active count for the given client queue name when called
+   * @param workerQueueName worker queue name
+   * @param clientQueueName client queue name
    */
   public void addMetricWaiting(final IntSupplier countSupplier, final String workerQueueName, final String clientQueueName) {
     waitingMetrics.put(clientQueueName, OpenTelemetryMetrics.METER


### PR DESCRIPTION
The metrics were put in the same map, thereby overriding previous added metrics for the same worker queue.