### PR TITLE
Metric fixes: load usage name to 'work', and removed clientName from description

### DIFF
--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/TaskManagerUsageMetricsWrapper.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/metrics/TaskManagerUsageMetricsWrapper.java
@@ -33,7 +33,7 @@ public class TaskManagerUsageMetricsWrapper {
     rabbitMQUsageMetrics = new UsageMetricsWrapper(meter, "aer.rabbitmq", true);
     workerPoolUsageMetrics = new UsageMetricsWrapper(meter, "aer.taskmanager.workerpool", false);
     taskManagerUsageMetrics = new UsageMetricsWrapper(meter, "aer.taskmanager", false);
-    loadUsageMetricsReporter = new UsageMetricsReporter(meter, "aer.taskmanager.worker.load", "Report average worker load");
+    loadUsageMetricsReporter = new UsageMetricsReporter(meter, "aer.taskmanager.work.load", "Report average worker load");
   }
 
   /**

--- a/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerMetrics.java
+++ b/source/taskmanager/src/main/java/nl/aerius/taskmanager/scheduler/priorityqueue/PriorityTaskSchedulerMetrics.java
@@ -74,7 +74,7 @@ class PriorityTaskSchedulerMetrics {
   public void addMetricWaiting(final IntSupplier countSupplier, final String workerQueueName, final String clientQueueName) {
     waitingMetrics.put(clientQueueName, OpenTelemetryMetrics.METER
         .gaugeBuilder(METRIC_PREFIX)
-        .setDescription(DESCRIPTION + clientQueueName)
+        .setDescription(DESCRIPTION)
         .buildWithCallback(
             result -> result.record(countSupplier.getAsInt(),
                 OpenTelemetryMetrics.queueAttributes(workerQueueName, clientQueueName, "state", "waiting"))));


### PR DESCRIPTION
- The metric name used to be `work.load` to keep backward compatible use that name (was correct in doc).
- Description of metric should be unique, so not including clientQueueName as that is an attribute not a specific metric separator.